### PR TITLE
Feature/eodhp 851 refactor fastapi to reduce number of indices

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -27,10 +27,11 @@ from stac_fastapi.api.models import (
     GeoJSONResponse,
     ItemCollectionUri,
     ItemUri,
+    BaseCollectionSearchGetRequest,
 )
 from stac_fastapi.api.openapi import update_openapi
 from stac_fastapi.api.routes import Scope, add_route_dependencies, create_async_endpoint
-from stac_fastapi.extensions.core.collection_search.request import BaseCollectionSearchGetRequest, BaseCollectionSearchAllGetRequest
+from stac_fastapi.extensions.core.collection_search.request import BaseCollectionSearchAllGetRequest
 from stac_fastapi.types.catalogs import Catalogs
 from stac_fastapi.types.config import ApiSettings, Settings
 from stac_fastapi.types.core import AsyncBaseCoreClient, BaseCoreClient
@@ -376,7 +377,7 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=create_async_endpoint(
-                self.client.all_collections, self.collections_get_all_request_model
+                self.client.all_collections, self.collections_get_request_model
             ),
         )
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -472,35 +472,6 @@ class StacApi:
             ),
         )
 
-    def register_get_catalogs(self):
-        """Register get catalogs endpoint (GET /catalogs).
-
-        Returns:
-            None
-        """
-        self.router.add_api_route(
-            name="Get Catalogs",
-            path="/catalogs/{cat_path:path}/catalogs",
-            response_model=(
-                Catalogs if self.settings.enable_response_models else None
-            ),
-            responses={
-                200: {
-                    "content": {
-                        MimeTypes.json.value: {},
-                    },
-                    "model": Catalogs,
-                },
-            },
-            response_class=self.response_class,
-            response_model_exclude_unset=True,
-            response_model_exclude_none=True,
-            methods=["GET"],
-            endpoint=create_async_endpoint(
-                self.client.all_catalogs, self.catalogs_get_request_model
-            ),
-        )
-
     def register_get_all_catalogs(self):
         """Register get catalogs endpoint (GET /catalogs).
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import attr
 from brotli_asgi import BrotliMiddleware
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Path
 from fastapi.openapi.utils import get_openapi
 from fastapi.params import Depends
 from stac_pydantic import api
@@ -14,11 +14,14 @@ from stac_pydantic.shared import MimeTypes
 from stac_pydantic.version import STAC_VERSION
 from starlette.middleware import Middleware
 from starlette.responses import JSONResponse, Response
+from typing_extensions import Annotated
+
 
 from stac_fastapi.api.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 from stac_fastapi.api.middleware import CORSMiddleware, ProxyHeaderMiddleware
 from stac_fastapi.api.models import (
     APIRequest,
+    CatalogUri,
     CollectionUri,
     EmptyRequest,
     GeoJSONResponse,
@@ -27,10 +30,12 @@ from stac_fastapi.api.models import (
 )
 from stac_fastapi.api.openapi import update_openapi
 from stac_fastapi.api.routes import Scope, add_route_dependencies, create_async_endpoint
+from stac_fastapi.extensions.core.collection_search.request import BaseCollectionSearchGetRequest, BaseCollectionSearchAllGetRequest
+from stac_fastapi.types.catalogs import Catalogs
 from stac_fastapi.types.config import ApiSettings, Settings
 from stac_fastapi.types.core import AsyncBaseCoreClient, BaseCoreClient
 from stac_fastapi.types.extension import ApiExtension
-from stac_fastapi.types.search import BaseSearchGetRequest, BaseSearchPostRequest
+from stac_fastapi.types.search import BaseSearchGetRequest, BaseSearchPostRequest, BaseSearchAllGetRequest
 
 
 @attr.s
@@ -103,10 +108,17 @@ class StacApi:
     search_get_request_model: Type[BaseSearchGetRequest] = attr.ib(
         default=BaseSearchGetRequest
     )
+    search_get_all_request_model: Type[BaseSearchAllGetRequest] = attr.ib(
+        default=BaseSearchAllGetRequest
+    )
     search_post_request_model: Type[BaseSearchPostRequest] = attr.ib(
         default=BaseSearchPostRequest
     )
-    collections_get_request_model: Type[APIRequest] = attr.ib(default=EmptyRequest)
+    catalogs_get_all_request_model: Type[APIRequest] = attr.ib(default=EmptyRequest)
+    catalogs_get_request_model: Type[APIRequest] = attr.ib(default=CatalogUri)
+    catalog_get_request_model: Type[APIRequest] = attr.ib(default=CatalogUri)
+    collections_get_all_request_model: Type[APIRequest] = attr.ib(default=BaseCollectionSearchAllGetRequest)
+    collections_get_request_model: Type[APIRequest] = attr.ib(default=BaseCollectionSearchGetRequest)
     collection_get_request_model: Type[APIRequest] = attr.ib(default=CollectionUri)
     items_get_request_model: Type[APIRequest] = attr.ib(default=ItemCollectionUri)
     item_get_request_model: Type[APIRequest] = attr.ib(default=ItemUri)
@@ -121,6 +133,7 @@ class StacApi:
         )
     )
     route_dependencies: List[Tuple[List[Scope], List[Depends]]] = attr.ib(default=[])
+
 
     def get_extension(self, extension: Type[ApiExtension]) -> Optional[ApiExtension]:
         """Get an extension.
@@ -198,7 +211,7 @@ class StacApi:
         """
         self.router.add_api_route(
             name="Get Item",
-            path="/collections/{collection_id}/items/{item_id}",
+            path="/catalogs/{cat_path:path}/collections/{collection_id}/items/{item_id}",
             response_model=api.Item if self.settings.enable_response_models else None,
             responses={
                 200: {
@@ -223,8 +236,71 @@ class StacApi:
         Returns:
             None
         """
+        @attr.s
+        class search_post_cat_request_model(APIRequest):
+            cat_path: Annotated[str, Path(description="Catalog path", regex=r"^(catalogs/[^/]+)(/catalogs/[^/]+)*")] = attr.ib()
+            search_request: self.search_post_request_model = attr.ib()
+
         self.router.add_api_route(
-            name="Search",
+            name="Search Items",
+            path="/catalogs/{cat_path:path}/search",
+            response_model=api.ItemCollection
+            if self.settings.enable_response_models
+            else None,
+            responses={
+                200: {
+                    "content": {
+                        MimeTypes.geojson.value: {},
+                    },
+                    "model": api.ItemCollection,
+                },
+            },
+            response_class=GeoJSONResponse,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["POST"],
+            endpoint=create_async_endpoint(
+                self.client.post_search, search_post_cat_request_model
+            ),
+        )
+
+    def register_get_search(self):
+        """Register search endpoint (GET /search).
+
+        Returns:
+            None
+        """
+        self.router.add_api_route(
+            name="Search Items",
+            path="/catalogs/{cat_path:path}/search",
+            response_model=api.ItemCollection
+            if self.settings.enable_response_models
+            else None,
+            responses={
+                200: {
+                    "content": {
+                        MimeTypes.geojson.value: {},
+                    },
+                    "model": api.ItemCollection,
+                },
+            },
+            response_class=GeoJSONResponse,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["GET"],
+            endpoint=create_async_endpoint(
+                self.client.get_search, self.search_get_request_model
+            ),
+        )
+
+    def register_post_all_search(self):
+        """Register search endpoint (POST /search).
+
+        Returns:
+            None
+        """
+        self.router.add_api_route(
+            name="Search All Items",
             path="/search",
             response_model=api.ItemCollection
             if self.settings.enable_response_models
@@ -246,14 +322,14 @@ class StacApi:
             ),
         )
 
-    def register_get_search(self):
+    def register_get_all_search(self):
         """Register search endpoint (GET /search).
 
         Returns:
             None
         """
         self.router.add_api_route(
-            name="Search",
+            name="Search All Items",
             path="/search",
             response_model=api.ItemCollection
             if self.settings.enable_response_models
@@ -271,7 +347,7 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=create_async_endpoint(
-                self.client.get_search, self.search_get_request_model
+                self.client.get_search, self.search_get_all_request_model
             ),
         )
 
@@ -283,6 +359,35 @@ class StacApi:
         """
         self.router.add_api_route(
             name="Get Collections",
+            path="/catalogs/{cat_path:path}/collections",
+            response_model=(
+                Collections if self.settings.enable_response_models else None
+            ),
+            responses={
+                200: {
+                    "content": {
+                        MimeTypes.json.value: {},
+                    },
+                    "model": Collections,
+                },
+            },
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["GET"],
+            endpoint=create_async_endpoint(
+                self.client.all_collections, self.collections_get_all_request_model
+            ),
+        )
+
+    def register_get_all_collections(self):
+        """Register get all collections endpoint (GET /collections).
+
+        Returns:
+            None
+        """
+        self.router.add_api_route(
+            name="Get All Collections",
             path="/collections",
             response_model=(
                 Collections if self.settings.enable_response_models else None
@@ -300,9 +405,10 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=create_async_endpoint(
-                self.client.all_collections, self.collections_get_request_model
+                self.client.all_collections, self.collections_get_all_request_model
             ),
         )
+
 
     def register_get_collection(self):
         """Register get collection endpoint (GET /collection/{collection_id}).
@@ -312,7 +418,7 @@ class StacApi:
         """
         self.router.add_api_route(
             name="Get Collection",
-            path="/collections/{collection_id}",
+            path="/catalogs/{cat_path:path}/collections/{collection_id}",
             response_model=api.Collection
             if self.settings.enable_response_models
             else None,
@@ -341,7 +447,7 @@ class StacApi:
         """
         self.router.add_api_route(
             name="Get ItemCollection",
-            path="/collections/{collection_id}/items",
+            path="/catalogs/{cat_path:path}/collections/{collection_id}/items",
             response_model=(
                 api.ItemCollection if self.settings.enable_response_models else None
             ),
@@ -359,6 +465,151 @@ class StacApi:
             methods=["GET"],
             endpoint=create_async_endpoint(
                 self.client.item_collection, self.items_get_request_model
+            ),
+        )
+
+    def register_get_catalogs(self):
+        """Register get catalogs endpoint (GET /catalogs).
+
+        Returns:
+            None
+        """
+        self.router.add_api_route(
+            name="Get Catalogs",
+            path="/catalogs/{cat_path:path}/catalogs",
+            response_model=(
+                Catalogs if self.settings.enable_response_models else None
+            ),
+            responses={
+                200: {
+                    "content": {
+                        MimeTypes.json.value: {},
+                    },
+                    "model": Catalogs,
+                },
+            },
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["GET"],
+            endpoint=create_async_endpoint(
+                self.client.all_catalogs, self.catalogs_get_request_model
+            ),
+        )
+
+    def register_get_all_catalogs(self):
+        """Register get catalogs endpoint (GET /catalogs).
+
+        Returns:
+            None
+        """
+        self.router.add_api_route(
+            name="Get All Catalogs",
+            path="/catalogs",
+            response_model=(
+                Catalogs if self.settings.enable_response_models else None
+            ),
+            responses={
+                200: {
+                    "content": {
+                        MimeTypes.json.value: {},
+                    },
+                    "model": Catalogs,
+                },
+            },
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["GET"],
+            endpoint=create_async_endpoint(
+                self.client.all_catalogs, self.catalogs_get_all_request_model
+            ),
+        )
+
+    def register_get_catalogs(self):
+        """Register get catalogs endpoint (GET /catalogs).
+
+        Returns:
+            None
+        """
+        self.router.add_api_route(
+            name="Get Catalogs",
+            path="/catalogs/{cat_path:path}/catalogs",
+            response_model=(
+                Catalogs if self.settings.enable_response_models else None
+            ),
+            responses={
+                200: {
+                    "content": {
+                        MimeTypes.json.value: {},
+                    },
+                    "model": Catalogs,
+                },
+            },
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["GET"],
+            endpoint=create_async_endpoint(
+                self.client.all_catalogs, self.catalogs_get_request_model
+            ),
+        )
+
+    def register_get_catalog(self):
+        """Register get catalog endpoint (GET /catalog/{cat_path}).
+
+        Returns:
+            None
+        """
+        self.router.add_api_route(
+            name="Get Catalog",
+            path="/catalogs/{cat_path:path}",
+            response_model=api.Collection
+            if self.settings.enable_response_models
+            else None,
+            responses={
+                200: {
+                    "content": {
+                        MimeTypes.json.value: {},
+                    },
+                    "model": api.Collection,
+                },
+            },
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["GET"],
+            endpoint=create_async_endpoint(
+                self.client.get_catalog, self.catalog_get_request_model
+            ),
+        )
+
+    def register_get_collection(self):
+        """Register get collection endpoint (GET /collection/{collection_id}).
+
+        Returns:
+            None
+        """
+        self.router.add_api_route(
+            name="Get Collection",
+            path="/catalogs/{cat_path:path}/collections/{collection_id}",
+            response_model=api.Collection
+            if self.settings.enable_response_models
+            else None,
+            responses={
+                200: {
+                    "content": {
+                        MimeTypes.json.value: {},
+                    },
+                    "model": api.Collection,
+                },
+            },
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["GET"],
+            endpoint=create_async_endpoint(
+                self.client.get_collection, self.collection_get_request_model
             ),
         )
 
@@ -383,10 +634,16 @@ class StacApi:
         self.register_conformance_classes()
         self.register_get_item()
         self.register_post_search()
+        self.register_post_all_search()
         self.register_get_search()
+        self.register_get_all_search()
         self.register_get_collections()
+        self.register_get_all_collections()
         self.register_get_collection()
         self.register_get_item_collection()
+        self.register_get_catalogs()
+        self.register_get_all_catalogs()
+        self.register_get_catalog()
 
     def customize_openapi(self) -> Optional[Dict[str, Any]]:
         """Customize openapi schema."""

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -242,7 +242,7 @@ class StacApi:
         """
         @attr.s
         class search_post_cat_request_model(APIRequest):
-            cat_path: Annotated[str, Path(description="Catalog path", regex=r"^(catalogs/[^/]+)(/catalogs/[^/]+)*")] = attr.ib()
+            cat_path: Annotated[str, Path(description="Catalog path", regex=r"^([^/]+)(/catalogs/[^/]+)*$")] = attr.ib()
             search_request: self.search_post_request_model = attr.ib()
 
         self.router.add_api_route(

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -18,6 +18,7 @@ from stac_fastapi.types.search import (
     Limit,
     _bbox_converter,
     _datetime_converter,
+    str2list,
 )
 
 try:
@@ -111,6 +112,24 @@ class CreateCatalogUri(APIRequest):
     """Get or delete catalog."""
 
     cat_path: Annotated[str, Path(description="Catalog path", regex=r"root$|(^([^/]+)(/catalogs/[^/]+)*$)")] = attr.ib()
+
+@attr.s
+class BaseCollectionSearchGetRequest(APIRequest):
+    """Get or delete catalog."""
+
+    cat_path: Annotated[str, Path(description="Catalog path", regex=r"root$|(^([^/]+)(/catalogs/[^/]+)*$)")] = attr.ib()
+    bbox: Optional[BBox] = attr.ib(default=None, converter=_bbox_converter)
+    datetime: Optional[DateTimeType] = attr.ib(
+        default=None, converter=_datetime_converter
+    )
+    limit: Annotated[
+        Optional[Limit],
+        Query(
+            description="Limits the number of results that are included in each page of the response."  # noqa: E501
+        ),
+    ] = attr.ib(default=10)
+    q: Optional[List[str]] = attr.ib(default=None, converter=str2list)
+
 
 
 @attr.s

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -108,6 +108,20 @@ class CatalogUri(APIRequest):
     cat_path: Annotated[str, Path(description="Catalog path", regex=r"^([^/]+)(/catalogs/[^/]+)*$")] = attr.ib()
 
 @attr.s
+class BaseCatalogUri(APIRequest):
+    """Get or delete catalog."""
+
+    catalog_id: Annotated[str, Path(description="Catalog ID", regex=r"^([^/]+)$")] = attr.ib()
+
+
+@attr.s
+class GetCatalogUri(APIRequest):
+    """Get or delete catalog."""
+
+    cat_path: Annotated[str, Path(description="Catalog path", regex=r"^([^/]+)(/catalogs/[^/]+)*$")] = attr.ib()
+    catalog_id: Annotated[str, Path(description="Catalog ID", regex=r"^([^/]+)$")] = attr.ib()
+
+@attr.s
 class CreateCatalogUri(APIRequest):
     """Get or delete catalog."""
 

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -115,8 +115,8 @@ def extract_headers(
         headers["X-Authenticated"] = True
     else:
         logger.info("User is not authenticated")
-        headers["X-Workspaces"] = ["tjellicoe-tpzuk"]
-        headers["X-Authenticated"] = True
+        headers["X-Workspaces"] = []
+        headers["X-Authenticated"] = False
 
     return headers  # Allows support for more headers in future, e.g. group information
 

--- a/stac_fastapi/api/stac_fastapi/api/settings.py
+++ b/stac_fastapi/api/stac_fastapi/api/settings.py
@@ -1,0 +1,9 @@
+import os
+
+KEYCLOAK_BASE_URL = os.getenv("KEYCLOAK_BASE_URL", "default_base_url")
+REALM = os.getenv("REALM", "default_realm")
+CLIENT_ID = os.getenv("CLIENT_ID", "default_client_id")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET", "default_client_secret")
+CACHE_CONTROL_HEADERS = os.getenv("CACHE_CONTROL_HEADERS", "max-age=300, stale-while-revalidate=300")
+CACHE_CONTROL_CATALOGS = os.getenv("CACHE_CONTROL_CATALOGS", "supported-datasets")
+CACHE_CONTROL_CATALOGS_LIST = CACHE_CONTROL_CATALOGS.split(',')

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/aggregation.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/aggregation.py
@@ -97,17 +97,19 @@ class AggregationExtension(ApiExtension):
             methods=["POST"],
             endpoint=create_async_endpoint(self.client.aggregate, self.POST),
         )
+
+        @attr.s
+        class GET_cat_path(CollectionUri, self.GET):
+            pass
+
         self.router.add_api_route(
             name="Collection Aggregate",
             path="/catalogs/{cat_path:path}/collections/{collection_id}/aggregate",
             methods=["GET"],
-            endpoint=create_async_endpoint(self.client.aggregate, self.GET),
+            endpoint=create_async_endpoint(self.client.aggregate, GET_cat_path),
         )
 
-        @attr.s
-        class POST_cat_path(APIRequest):
-            cat_path: Annotated[str, Path(description="Catalog path", regex=r"^(catalogs/[^/]+)(/catalogs/[^/]+)*")] = attr.ib()
-            collection_id: Annotated[str, Path(description="Collection ID")] = attr.ib()
+        class POST_cat_path(CollectionUri):
             search_request: self.POST = attr.ib()
             
         self.router.add_api_route(

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/aggregation.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/aggregation.py
@@ -79,18 +79,42 @@ class AggregationExtension(ApiExtension):
             methods=["GET", "POST"],
             endpoint=create_async_endpoint(self.client.get_aggregations, EmptyRequest),
         )
+
+        @attr.s
+        class GET_cat_path_collection(CollectionUri, self.GET):
+            pass
+
         self.router.add_api_route(
-            name="Catalog Aggregations",
-            path="/catalogs/{cat_path:path}/aggregations",
-            methods=["GET", "POST"],
-            endpoint=create_async_endpoint(self.client.get_aggregations, CatalogUri),
+            name="Collection Aggregate",
+            path="/catalogs/{cat_path:path}/collections/{collection_id}/aggregate",
+            methods=["GET"],
+            endpoint=create_async_endpoint(self.client.aggregate, GET_cat_path_collection),
         )
+
+        class POST_cat_path(CollectionUri):
+            search_request: self.POST = attr.ib()
+            
+        self.router.add_api_route(
+            name="Collection Aggregate",
+            path="/catalogs/{cat_path:path}/collections/{collection_id}/aggregate",
+            methods=["POST"],
+            endpoint=create_async_endpoint(self.client.aggregate, POST_cat_path),
+        )
+
         self.router.add_api_route(
             name="Collection Aggregations",
             path="/catalogs/{cat_path:path}/collections/{collection_id}/aggregations",
             methods=["GET", "POST"],
             endpoint=create_async_endpoint(self.client.get_aggregations, CollectionUri),
         )
+
+        self.router.add_api_route(
+            name="Catalog Aggregations",
+            path="/catalogs/{cat_path:path}/aggregations",
+            methods=["GET", "POST"],
+            endpoint=create_async_endpoint(self.client.get_aggregations, CatalogUri),
+        )
+        
         self.router.add_api_route(
             name="Aggregate",
             path="/aggregate",
@@ -115,24 +139,4 @@ class AggregationExtension(ApiExtension):
             endpoint=create_async_endpoint(self.client.aggregate, self.POST),
         )
 
-        @attr.s
-        class GET_cat_path_collection(CollectionUri, self.GET):
-            pass
-
-        self.router.add_api_route(
-            name="Collection Aggregate",
-            path="/catalogs/{cat_path:path}/collections/{collection_id}/aggregate",
-            methods=["GET"],
-            endpoint=create_async_endpoint(self.client.aggregate, GET_cat_path_collection),
-        )
-
-        class POST_cat_path(CollectionUri):
-            search_request: self.POST = attr.ib()
-            
-        self.router.add_api_route(
-            name="Collection Aggregate",
-            path="/catalogs/{cat_path:path}/collections/{collection_id}/aggregate",
-            methods=["POST"],
-            endpoint=create_async_endpoint(self.client.aggregate, POST_cat_path),
-        )
         app.include_router(self.router, tags=["Aggregation Extension"])

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/aggregation.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/aggregation.py
@@ -81,7 +81,7 @@ class AggregationExtension(ApiExtension):
         )
         self.router.add_api_route(
             name="Sub Aggregations",
-            path="/{cat_path:path}/aggregations",
+            path="catalogs/{cat_path:path}/aggregations",
             methods=["GET", "POST"],
             endpoint=create_async_endpoint(self.client.get_aggregations, CatalogUri),
         )
@@ -104,7 +104,7 @@ class AggregationExtension(ApiExtension):
 
         self.router.add_api_route(
             name="Sub Aggregate",
-            path="/{cat_path:path}/aggregate",
+            path="catalogs/{cat_path:path}/aggregate",
             methods=["GET"],
             endpoint=create_async_endpoint(self.client.aggregate, GET_cat_path),
         )

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/aggregation.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/aggregation.py
@@ -6,7 +6,7 @@ from typing_extensions import Annotated
 import attr
 from fastapi import APIRouter, FastAPI, Path
 
-from stac_fastapi.api.models import CollectionUri, EmptyRequest, APIRequest
+from stac_fastapi.api.models import CollectionUri, EmptyRequest, CatalogUri
 from stac_fastapi.api.routes import create_async_endpoint
 from stac_fastapi.types.extension import ApiExtension
 
@@ -80,6 +80,12 @@ class AggregationExtension(ApiExtension):
             endpoint=create_async_endpoint(self.client.get_aggregations, EmptyRequest),
         )
         self.router.add_api_route(
+            name="Sub Aggregations",
+            path="/{cat_path:path}/aggregations",
+            methods=["GET", "POST"],
+            endpoint=create_async_endpoint(self.client.get_aggregations, CatalogUri),
+        )
+        self.router.add_api_route(
             name="Collection Aggregations",
             path="/catalogs/{cat_path:path}/collections/{collection_id}/aggregations",
             methods=["GET", "POST"],
@@ -91,6 +97,17 @@ class AggregationExtension(ApiExtension):
             methods=["GET"],
             endpoint=create_async_endpoint(self.client.aggregate, self.GET),
         )
+
+        @attr.s
+        class GET_cat_path(CatalogUri, self.GET):
+            pass
+
+        self.router.add_api_route(
+            name="Sub Aggregate",
+            path="/{cat_path:path}/aggregate",
+            methods=["GET"],
+            endpoint=create_async_endpoint(self.client.aggregate, GET_cat_path),
+        )
         self.router.add_api_route(
             name="Aggregate",
             path="/aggregate",
@@ -99,14 +116,14 @@ class AggregationExtension(ApiExtension):
         )
 
         @attr.s
-        class GET_cat_path(CollectionUri, self.GET):
+        class GET_cat_path_collection(CollectionUri, self.GET):
             pass
 
         self.router.add_api_route(
             name="Collection Aggregate",
             path="/catalogs/{cat_path:path}/collections/{collection_id}/aggregate",
             methods=["GET"],
-            endpoint=create_async_endpoint(self.client.aggregate, GET_cat_path),
+            endpoint=create_async_endpoint(self.client.aggregate, GET_cat_path_collection),
         )
 
         class POST_cat_path(CollectionUri):

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/aggregation.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/aggregation.py
@@ -81,7 +81,7 @@ class AggregationExtension(ApiExtension):
         )
         self.router.add_api_route(
             name="Sub Aggregations",
-            path="catalogs/{cat_path:path}/aggregations",
+            path="/catalogs/{cat_path:path}/aggregations",
             methods=["GET", "POST"],
             endpoint=create_async_endpoint(self.client.get_aggregations, CatalogUri),
         )
@@ -104,7 +104,7 @@ class AggregationExtension(ApiExtension):
 
         self.router.add_api_route(
             name="Sub Aggregate",
-            path="catalogs/{cat_path:path}/aggregate",
+            path="/catalogs/{cat_path:path}/aggregate",
             methods=["GET"],
             endpoint=create_async_endpoint(self.client.aggregate, GET_cat_path),
         )

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/aggregation.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/aggregation.py
@@ -80,7 +80,7 @@ class AggregationExtension(ApiExtension):
             endpoint=create_async_endpoint(self.client.get_aggregations, EmptyRequest),
         )
         self.router.add_api_route(
-            name="Sub Aggregations",
+            name="Catalog Aggregations",
             path="/catalogs/{cat_path:path}/aggregations",
             methods=["GET", "POST"],
             endpoint=create_async_endpoint(self.client.get_aggregations, CatalogUri),
@@ -103,7 +103,7 @@ class AggregationExtension(ApiExtension):
             pass
 
         self.router.add_api_route(
-            name="Sub Aggregate",
+            name="Catalog Aggregate",
             path="/catalogs/{cat_path:path}/aggregate",
             methods=["GET"],
             endpoint=create_async_endpoint(self.client.aggregate, GET_cat_path),

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/client.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/client.py
@@ -21,7 +21,7 @@ class BaseAggregationClient(abc.ABC):
     # AGGREGATION_COLLECTION = AggregationCollection
 
     def get_aggregations(
-        self, collection_id: Optional[str] = None, **kwargs
+        self, cat_path: Optional[str] = None, collection_id: Optional[str] = None, **kwargs
     ) -> AggregationCollection:
         """Get the aggregations available for the given collection_id.
 
@@ -46,7 +46,7 @@ class BaseAggregationClient(abc.ABC):
         )
 
     def aggregate(
-        self, collection_id: Optional[str] = None, **kwargs
+        self, cat_path: Optional[str] = None, collection_id: Optional[str] = None, **kwargs
     ) -> AggregationCollection:
         """Return the aggregation buckets for a given search result"""
         return AggregationCollection(
@@ -76,7 +76,7 @@ class AsyncBaseAggregationClient(abc.ABC):
     # AGGREGATION_COLLECTION = AggregationCollection
 
     async def get_aggregations(
-        self, collection_id: Optional[str] = None, **kwargs
+        self, cat_path: Optional[str] = None, collection_id: Optional[str] = None, **kwargs
     ) -> AggregationCollection:
         """Get the aggregations available for the given collection_id.
 
@@ -102,6 +102,7 @@ class AsyncBaseAggregationClient(abc.ABC):
 
     async def aggregate(
         self,
+        cat_path: Optional[str] = None,
         collection_id: Optional[str] = None,
         aggregations: Optional[Union[str, List[str]]] = None,
         collections: Optional[List[str]] = None,

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/request.py
@@ -3,7 +3,7 @@
 from typing import List, Optional
 
 import attr
-from fastapi import Query
+from fastapi import Query, Path, Body
 from pydantic import Field
 from typing_extensions import Annotated
 
@@ -12,6 +12,7 @@ from stac_fastapi.types.search import (
     BaseSearchPostRequest,
     str2list,
 )
+from stac_fastapi.api.models import APIRequest
 
 
 def _agg_converter(
@@ -30,9 +31,20 @@ class AggregationExtensionGetRequest(BaseSearchGetRequest):
     aggregations: Optional[List[str]] = attr.ib(default=None, converter=_agg_converter)
 
 
+class TempAggregationExtensionPostRequest(BaseSearchPostRequest):
+    """Aggregation Extension POST request model."""
+
+    aggregations: Optional[List[str]] = Field(
+        default=None,
+        description="A list of aggregations to compute and return.",
+    )
+
+
 class AggregationExtensionPostRequest(BaseSearchPostRequest):
     """Aggregation Extension POST request model."""
 
+    #cat_path: Annotated[str, Path(description="Catalog path", regex=r"^(catalogs/[^/]+)(/catalogs/[^/]+)*")] = attr.ib()
+    # request_body: TempAggregationExtensionPostRequest = Body(...)
     aggregations: Optional[List[str]] = Field(
         default=None,
         description="A list of aggregations to compute and return.",

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/request.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from typing_extensions import Annotated
 
 from stac_fastapi.types.search import (
-    BaseSearchGetRequest,
+    BaseSearchAllGetRequest,
     BaseSearchPostRequest,
     str2list,
 )
@@ -25,7 +25,7 @@ def _agg_converter(
 
 
 @attr.s
-class AggregationExtensionGetRequest(BaseSearchGetRequest):
+class AggregationExtensionGetRequest(BaseSearchAllGetRequest):
     """Aggregation Extension GET request model."""
 
     aggregations: Optional[List[str]] = attr.ib(default=None, converter=_agg_converter)
@@ -43,8 +43,6 @@ class TempAggregationExtensionPostRequest(BaseSearchPostRequest):
 class AggregationExtensionPostRequest(BaseSearchPostRequest):
     """Aggregation Extension POST request model."""
 
-    #cat_path: Annotated[str, Path(description="Catalog path", regex=r"^(catalogs/[^/]+)(/catalogs/[^/]+)*")] = attr.ib()
-    # request_body: TempAggregationExtensionPostRequest = Body(...)
     aggregations: Optional[List[str]] = Field(
         default=None,
         description="A list of aggregations to compute and return.",

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/collection_search.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/collection_search.py
@@ -1,14 +1,16 @@
 """Collection-Search extension."""
 
+import warnings
 from enum import Enum
 from typing import List, Optional, Union
+from typing_extensions import Annotated
 
 import attr
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Path
 from stac_pydantic.api.collections import Collections
 from stac_pydantic.shared import MimeTypes
 
-from stac_fastapi.api.models import GeoJSONResponse, create_request_model
+from stac_fastapi.api.models import GeoJSONResponse, create_request_model, APIRequest
 from stac_fastapi.api.routes import create_async_endpoint
 from stac_fastapi.types.config import ApiSettings
 from stac_fastapi.types.extension import ApiExtension
@@ -78,7 +80,7 @@ class CollectionSearchExtension(ApiExtension):
         schema_href: Optional[str] = None,
     ) -> "CollectionSearchExtension":
         """Create CollectionSearchExtension object from extensions."""
-        known_extension_conformances = {
+        supported_extensions = {
             "FreeTextExtension": ConformanceClasses.FREETEXT,
             "FreeTextAdvancedExtension": ConformanceClasses.FREETEXT,
             "QueryExtension": ConformanceClasses.QUERY,
@@ -91,7 +93,13 @@ class CollectionSearchExtension(ApiExtension):
             ConformanceClasses.BASIS,
         ]
         for ext in extensions:
-            if conf := known_extension_conformances.get(ext.__class__.__name__, None):
+            conf = supported_extensions.get(ext.__class__.__name__, None)
+            if not conf:
+                warnings.warn(
+                    f"Conformance class for `{ext.__class__.__name__}` extension not found.",  # noqa: E501
+                    UserWarning,
+                )
+            else:
                 conformance_classes.append(conf)
 
         get_request_model = create_request_model(
@@ -150,7 +158,7 @@ class CollectionSearchPostExtension(CollectionSearchExtension):
         self.router.prefix = app.state.router_prefix
 
         self.router.add_api_route(
-            name="Collections",
+            name="Post All Collections",
             path="/collections",
             methods=["POST"],
             response_model=(
@@ -167,7 +175,32 @@ class CollectionSearchPostExtension(CollectionSearchExtension):
             response_class=GeoJSONResponse,
             endpoint=create_async_endpoint(self.client.post_all_collections, self.POST),
         )
+
+        @attr.s
+        class POST_cat_path(APIRequest):
+            cat_path: Annotated[str, Path(description="Catalog path", regex=r"^(catalogs/[^/]+)(/catalogs/[^/]+)*")] = attr.ib()
+            search_request: self.POST = attr.ib()
+
+        self.router.add_api_route(
+            name="Post Collections",
+            path="/catalogs/{cat_path:path}/collections",
+            methods=["POST"],
+            response_model=(
+                Collections if self.settings.enable_response_models else None
+            ),
+            responses={
+                200: {
+                    "content": {
+                        MimeTypes.json.value: {},
+                    },
+                    "model": Collections,
+                },
+            },
+            response_class=GeoJSONResponse,
+            endpoint=create_async_endpoint(self.client.post_all_collections, POST_cat_path),
+        )
         app.include_router(self.router)
+
 
     @classmethod
     def from_extensions(
@@ -180,7 +213,7 @@ class CollectionSearchPostExtension(CollectionSearchExtension):
         router: Optional[APIRouter] = None,
     ) -> "CollectionSearchPostExtension":
         """Create CollectionSearchPostExtension object from extensions."""
-        known_extension_conformances = {
+        supported_extensions = {
             "FreeTextExtension": ConformanceClasses.FREETEXT,
             "FreeTextAdvancedExtension": ConformanceClasses.FREETEXT,
             "QueryExtension": ConformanceClasses.QUERY,
@@ -193,7 +226,13 @@ class CollectionSearchPostExtension(CollectionSearchExtension):
             ConformanceClasses.BASIS,
         ]
         for ext in extensions:
-            if conf := known_extension_conformances.get(ext.__class__.__name__, None):
+            conf = supported_extensions.get(ext.__class__.__name__, None)
+            if not conf:
+                warnings.warn(
+                    f"Conformance class for `{ext.__class__.__name__}` extension not found.",  # noqa: E501
+                    UserWarning,
+                )
+            else:
                 conformance_classes.append(conf)
 
         get_request_model = create_request_model(

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/collection_search.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/collection_search.py
@@ -16,7 +16,7 @@ from stac_fastapi.types.config import ApiSettings
 from stac_fastapi.types.extension import ApiExtension
 
 from .client import AsyncBaseCollectionSearchClient, BaseCollectionSearchClient
-from .request import BaseCollectionSearchGetRequest, BaseCollectionSearchPostRequest
+from .request import BaseCollectionSearchAllGetRequest, BaseCollectionSearchPostRequest
 
 
 class ConformanceClasses(str, Enum):
@@ -54,7 +54,7 @@ class CollectionSearchExtension(ApiExtension):
             the extension
     """
 
-    GET: BaseCollectionSearchGetRequest = attr.ib(default=BaseCollectionSearchGetRequest)
+    GET: BaseCollectionSearchAllGetRequest = attr.ib(default=BaseCollectionSearchAllGetRequest)
     POST = None
 
     conformance_classes: List[str] = attr.ib(
@@ -104,7 +104,7 @@ class CollectionSearchExtension(ApiExtension):
 
         get_request_model = create_request_model(
             model_name="CollectionsGetRequest",
-            base_model=BaseCollectionSearchGetRequest,
+            base_model=BaseCollectionSearchAllGetRequest,
             extensions=extensions,
             request_type="GET",
         )
@@ -141,7 +141,7 @@ class CollectionSearchPostExtension(CollectionSearchExtension):
     schema_href: Optional[str] = attr.ib(default=None)
     router: APIRouter = attr.ib(factory=APIRouter)
 
-    GET: BaseCollectionSearchGetRequest = attr.ib(default=BaseCollectionSearchGetRequest)
+    GET: BaseCollectionSearchAllGetRequest = attr.ib(default=BaseCollectionSearchAllGetRequest)
     POST: BaseCollectionSearchPostRequest = attr.ib(
         default=BaseCollectionSearchPostRequest
     )
@@ -178,7 +178,7 @@ class CollectionSearchPostExtension(CollectionSearchExtension):
 
         @attr.s
         class POST_cat_path(APIRequest):
-            cat_path: Annotated[str, Path(description="Catalog path", regex=r"^(catalogs/[^/]+)(/catalogs/[^/]+)*")] = attr.ib()
+            cat_path: Annotated[str, Path(description="Catalog path", regex=r"^([^/]+)(/catalogs/[^/]+)*$")] = attr.ib()
             search_request: self.POST = attr.ib()
 
         self.router.add_api_route(
@@ -237,7 +237,7 @@ class CollectionSearchPostExtension(CollectionSearchExtension):
 
         get_request_model = create_request_model(
             model_name="CollectionsGetRequest",
-            base_model=BaseCollectionSearchGetRequest,
+            base_model=BaseCollectionSearchAllGetRequest,
             extensions=extensions,
             request_type="GET",
         )

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
@@ -16,8 +16,8 @@ from stac_fastapi.types.search import (
     Limit,
     _bbox_converter,
     _datetime_converter,
+    str2list,
 )
-
 
 @attr.s
 class BaseCollectionSearchAllGetRequest(APIRequest):
@@ -33,50 +33,21 @@ class BaseCollectionSearchAllGetRequest(APIRequest):
             description="Limits the number of results that are included in each page of the response."  # noqa: E501
         ),
     ] = attr.ib(default=10)
-
-
-@attr.s
-class BaseCollectionSearchGetRequest(BaseCollectionSearchAllGetRequest):
-    """Basics additional Collection-Search parameters for the GET request."""
-
-    bbox: Optional[BBox] = attr.ib(default=None, converter=_bbox_converter)
-    datetime: Optional[DateTimeType] = attr.ib(
-        default=None, converter=_datetime_converter
-    )
-    limit: Annotated[
-        Optional[Limit],
-        Query(
-            description="Limits the number of results that are included in each page of the response."  # noqa: E501
-        ),
-    ] = attr.ib(default=10)
+    q: Optional[List[str]] = attr.ib(default=None, converter=str2list)
 
 
 class BaseCollectionSearchPostRequest(BaseModel):
     """Collection-Search POST model."""
 
-    bbox: Optional[BBox] = Field(
-        default=None,
-        description="Only return items intersecting this bounding box. Mutually exclusive with **intersects**.",  # noqa: E501
-        json_schema_extra={
-            "example": [-175.05, -85.05, 175.05, 85.05],
-        },
-    )
-    datetime: Optional[str] = Field(
-        default=None,
-        description="""Only return items that have a temporal property that intersects this value.\n
-Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.""",  # noqa: E501
-        json_schema_extra={
-            "examples": {
-                "datetime": {"value": "2018-02-12T23:20:50Z"},
-                "closed-interval": {"value": "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"},
-                "open-interval-from": {"value": "2018-02-12T00:00:00Z/.."},
-                "open-interval-to": {"value": "../2018-03-18T12:31:12Z"},
-            },
-        },
-    )
+    bbox: Optional[BBox] = None
+    datetime: Optional[str] = None
     limit: Optional[Limit] = Field(
         10,
         description="Limits the number of results that are included in each page of the response (capped to 10_000).",  # noqa: E501
+    )
+    q: Optional[List[str]] = Field(
+        None,
+        description="Parameter to perform free-text queries against STAC metadata",
     )
 
     # Private properties to store the parsed datetime values.

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
@@ -4,28 +4,45 @@ from datetime import datetime as dt
 from typing import List, Optional, Tuple, cast
 
 import attr
-from fastapi import Query
+from fastapi import Query, Path
 from pydantic import BaseModel, Field, field_validator
 from stac_pydantic.api.search import SearchDatetime
 from stac_pydantic.shared import BBox
 from typing_extensions import Annotated
 
+from stac_fastapi.types.rfc3339 import DateTimeType
 from stac_fastapi.types.search import (
     APIRequest,
-    DatetimeMixin,
-    DateTimeQueryType,
     Limit,
     _bbox_converter,
-    _validate_datetime,
+    _datetime_converter,
 )
 
 
 @attr.s
-class BaseCollectionSearchGetRequest(APIRequest, DatetimeMixin):
+class BaseCollectionSearchAllGetRequest(APIRequest):
     """Basics additional Collection-Search parameters for the GET request."""
 
     bbox: Optional[BBox] = attr.ib(default=None, converter=_bbox_converter)
-    datetime: DateTimeQueryType = attr.ib(default=None, validator=_validate_datetime)
+    datetime: Optional[DateTimeType] = attr.ib(
+        default=None, converter=_datetime_converter
+    )
+    limit: Annotated[
+        Optional[Limit],
+        Query(
+            description="Limits the number of results that are included in each page of the response."  # noqa: E501
+        ),
+    ] = attr.ib(default=10)
+
+
+@attr.s
+class BaseCollectionSearchGetRequest(BaseCollectionSearchAllGetRequest):
+    """Basics additional Collection-Search parameters for the GET request."""
+
+    bbox: Optional[BBox] = attr.ib(default=None, converter=_bbox_converter)
+    datetime: Optional[DateTimeType] = attr.ib(
+        default=None, converter=_datetime_converter
+    )
     limit: Annotated[
         Optional[Limit],
         Query(

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/client.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/client.py
@@ -11,7 +11,7 @@ class AsyncBaseFiltersClient(abc.ABC):
     """Defines a pattern for implementing the STAC filter extension."""
 
     async def get_queryables(
-        self, collection_id: Optional[str] = None, **kwargs
+        self, cat_path: Optional[str] = None, collection_id: Optional[str] = None, **kwargs
     ) -> Dict[str, Any]:
         """Get the queryables available for the given collection_id.
 
@@ -37,7 +37,7 @@ class BaseFiltersClient(abc.ABC):
     """Defines a pattern for implementing the STAC filter extension."""
 
     def get_queryables(
-        self, collection_id: Optional[str] = None, **kwargs
+        self, cat_path: Optional[str] = None, collection_id: Optional[str] = None, **kwargs
     ) -> Dict[str, Any]:
         """Get the queryables available for the given collection_id.
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -7,7 +7,7 @@ import attr
 from fastapi import APIRouter, FastAPI
 from starlette.responses import Response
 
-from stac_fastapi.api.models import CollectionUri, EmptyRequest, JSONSchemaResponse
+from stac_fastapi.api.models import CatalogUri, CollectionUri, EmptyRequest, JSONSchemaResponse
 from stac_fastapi.api.routes import create_async_endpoint
 from stac_fastapi.types.extension import ApiExtension
 
@@ -122,5 +122,20 @@ class FilterExtension(ApiExtension):
             },
             response_class=self.response_class,
             endpoint=create_async_endpoint(self.client.get_queryables, CollectionUri),
+        )
+        self.router.add_api_route(
+            name="Catalog Queryables",
+            path="catalogs/{cat_path:path}/queryables",
+            methods=["GET"],
+            responses={
+                200: {
+                    "content": {
+                        "application/schema+json": {},
+                    },
+                    # TODO: add output model in stac-pydantic
+                },
+            },
+            response_class=self.response_class,
+            endpoint=create_async_endpoint(self.client.get_queryables, CatalogUri),
         )
         app.include_router(self.router, tags=["Filter Extension"])

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -94,8 +94,8 @@ class FilterExtension(ApiExtension):
         """
         self.router.prefix = app.state.router_prefix
         self.router.add_api_route(
-            name="Queryables",
-            path="/queryables",
+            name="Collection Queryables",
+            path="/catalogs/{cat_path:path}/collections/{collection_id}/queryables",
             methods=["GET"],
             responses={
                 200: {
@@ -106,9 +106,8 @@ class FilterExtension(ApiExtension):
                 },
             },
             response_class=self.response_class,
-            endpoint=create_async_endpoint(self.client.get_queryables, EmptyRequest),
+            endpoint=create_async_endpoint(self.client.get_queryables, CollectionUri),
         )
-        self.router.prefix = app.state.router_prefix
         self.router.add_api_route(
             name="Catalog Queryables",
             path="/catalogs/{cat_path:path}/queryables",
@@ -125,8 +124,8 @@ class FilterExtension(ApiExtension):
             endpoint=create_async_endpoint(self.client.get_queryables, CatalogUri),
         )
         self.router.add_api_route(
-            name="Collection Queryables",
-            path="/catalogs/{cat_path:path}/collections/{collection_id}/queryables",
+            name="Queryables",
+            path="/queryables",
             methods=["GET"],
             responses={
                 200: {
@@ -137,6 +136,6 @@ class FilterExtension(ApiExtension):
                 },
             },
             response_class=self.response_class,
-            endpoint=create_async_endpoint(self.client.get_queryables, CollectionUri),
+            endpoint=create_async_endpoint(self.client.get_queryables, EmptyRequest),
         )
         app.include_router(self.router, tags=["Filter Extension"])

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -110,7 +110,7 @@ class FilterExtension(ApiExtension):
         )
         self.router.add_api_route(
             name="Collection Queryables",
-            path="catalogs/{cat_path:path}/collections/{collection_id}/queryables",
+            path="/catalogs/{cat_path:path}/collections/{collection_id}/queryables",
             methods=["GET"],
             responses={
                 200: {
@@ -125,7 +125,7 @@ class FilterExtension(ApiExtension):
         )
         self.router.add_api_route(
             name="Catalog Queryables",
-            path="catalogs/{cat_path:path}/queryables",
+            path="/catalogs/{cat_path:path}/queryables",
             methods=["GET"],
             responses={
                 200: {

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -123,19 +123,4 @@ class FilterExtension(ApiExtension):
             response_class=self.response_class,
             endpoint=create_async_endpoint(self.client.get_queryables, CollectionUri),
         )
-        self.router.add_api_route(
-            name="Catalog Queryables",
-            path="/catalogs/{cat_path:path}/queryables",
-            methods=["GET"],
-            responses={
-                200: {
-                    "content": {
-                        "application/schema+json": {},
-                    },
-                    # TODO: add output model in stac-pydantic
-                },
-            },
-            response_class=self.response_class,
-            endpoint=create_async_endpoint(self.client.get_queryables, CatalogUri),
-        )
         app.include_router(self.router, tags=["Filter Extension"])

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -108,6 +108,22 @@ class FilterExtension(ApiExtension):
             response_class=self.response_class,
             endpoint=create_async_endpoint(self.client.get_queryables, EmptyRequest),
         )
+        self.router.prefix = app.state.router_prefix
+        self.router.add_api_route(
+            name="Catalog Queryables",
+            path="/catalogs/{cat_path:path}/queryables",
+            methods=["GET"],
+            responses={
+                200: {
+                    "content": {
+                        "application/schema+json": {},
+                    },
+                    # TODO: add output model in stac-pydantic
+                },
+            },
+            response_class=self.response_class,
+            endpoint=create_async_endpoint(self.client.get_queryables, CatalogUri),
+        )
         self.router.add_api_route(
             name="Collection Queryables",
             path="/catalogs/{cat_path:path}/collections/{collection_id}/queryables",

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -110,7 +110,7 @@ class FilterExtension(ApiExtension):
         )
         self.router.add_api_route(
             name="Collection Queryables",
-            path="/collections/{collection_id}/queryables",
+            path="catalogs/{cat_path:path}/collections/{collection_id}/queryables",
             methods=["GET"],
             responses={
                 200: {

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -80,13 +80,6 @@ class PutCatalog(CatalogUri):
     catalog: Annotated[Catalog, Body()] = attr.ib(default=None)
 
 @attr.s
-class PutBaseCatalog(BaseCatalogUri):
-    """Update Catalog."""
-
-    workspace: str = attr.ib()
-    catalog: Annotated[Catalog, Body()] = attr.ib(default=None)
-
-@attr.s
 class PutCatalogAccessControl(CatalogUri):
     """Update Catalog."""
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -73,7 +73,7 @@ class PostCatalog(CreateCatalogUri):
     catalog: Annotated[Catalog, Body()] = attr.ib(default=None)
 
 @attr.s
-class PutCatalog(GetCatalogUri):
+class PutCatalog(CatalogUri):
     """Update Catalog."""
 
     workspace: str = attr.ib()
@@ -294,7 +294,7 @@ class TransactionExtension(ApiExtension):
         """Register update catalog endpoint (PUT /collections/{collection_id})."""
         self.router.add_api_route(
             name="Update Catalog",
-            path="/catalogs/{cat_path:path}/catalogs/{catalog_id}",
+            path="/catalogs/{cat_path:path}",
             response_model=Catalog if self.settings.enable_response_models else None,
             responses={
                 200: {
@@ -311,26 +311,6 @@ class TransactionExtension(ApiExtension):
             endpoint=create_async_endpoint(self.client.update_catalog, PutCatalog),
         )
 
-    def register_update_base_catalog(self):
-        """Register update catalog endpoint (PUT /collections/{collection_id})."""
-        self.router.add_api_route(
-            name="Update Base Catalog",
-            path="/catalogs/{catalog_id}",
-            response_model=Catalog if self.settings.enable_response_models else None,
-            responses={
-                200: {
-                    "content": {
-                        MimeTypes.json.value: {},
-                    },
-                    "model": Catalog,
-                }
-            },
-            response_class=self.response_class,
-            response_model_exclude_unset=True,
-            response_model_exclude_none=True,
-            methods=["PUT"],
-            endpoint=create_async_endpoint(self.client.update_catalog, PutBaseCatalog),
-        )
 
     def register_update_collection_access_control(self):
         """Register update collection endpoint (PUT /collections/{collection_id})."""
@@ -418,7 +398,6 @@ class TransactionExtension(ApiExtension):
         self.register_delete_collection()
         self.register_create_catalog()
         self.register_update_catalog()
-        self.register_update_base_catalog()
         self.register_update_catalog_access_control()
         self.register_delete_catalog()
         app.include_router(self.router, tags=["Transaction Extension"])

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -9,7 +9,7 @@ from stac_pydantic.shared import MimeTypes
 from starlette.responses import JSONResponse, Response
 from typing_extensions import Annotated
 
-from stac_fastapi.api.models import CatalogUri, CreateCatalogUri, CollectionUri, ItemUri
+from stac_fastapi.api.models import CatalogUri, GetCatalogUri, CreateCatalogUri, CollectionUri, ItemUri
 from stac_fastapi.api.routes import create_async_endpoint
 from stac_fastapi.types.access_policy import AccessPolicy
 from stac_fastapi.types.config import ApiSettings
@@ -73,7 +73,7 @@ class PostCatalog(CreateCatalogUri):
     catalog: Annotated[Catalog, Body()] = attr.ib(default=None)
 
 @attr.s
-class PutCatalog(CatalogUri):
+class PutCatalog(GetCatalogUri):
     """Update Catalog."""
 
     workspace: str = attr.ib()

--- a/stac_fastapi/types/stac_fastapi/types/access_policy.py
+++ b/stac_fastapi/types/stac_fastapi/types/access_policy.py
@@ -1,0 +1,20 @@
+"""Access Policy Types"""
+
+import sys
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from stac_pydantic.shared import BBox
+
+# Avoids a Pydantic error:
+# TypeError: You should use `typing_extensions.TypedDict` instead of
+# `typing.TypedDict` with Python < 3.12.0.  Without it, there is no way to
+# differentiate required and optional fields when subclassed.
+if sys.version_info < (3, 12, 0):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
+
+class AccessPolicy(TypedDict, total=False):
+    """Metadata Access Policy."""
+
+    public: bool

--- a/stac_fastapi/types/stac_fastapi/types/catalogs.py
+++ b/stac_fastapi/types/stac_fastapi/types/catalogs.py
@@ -1,0 +1,35 @@
+from typing import List, Optional
+
+from pydantic import model_validator
+
+from stac_pydantic.catalog import Catalog
+from stac_pydantic.api.links import Links
+from stac_pydantic.links import Relations
+from stac_pydantic.shared import StacBaseModel
+
+
+class Catalogs(StacBaseModel):
+    """
+    https://github.com/radiantearth/stac-api-spec/tree/v1.0.0/ogcapi-features#endpoints
+    https://github.com/radiantearth/stac-api-spec/tree/v1.0.0/ogcapi-features#collections-collections
+    """
+
+    links: Links
+    catalogs: List[Catalog]
+    numberMatched: Optional[int] = None
+    numberReturned: Optional[int] = None
+
+    @model_validator(mode="after")
+    def required_links(self) -> "Catalogs":
+        links_rel = []
+        for link in self.links.root:
+            links_rel.append(link.rel)
+
+        required_rels = [Relations.root, Relations.self]
+
+        for rel in required_rels:
+            assert (
+                rel in links_rel
+            ), f"STAC API Catalogs conform Catalogs pages must include a `{rel}` link."
+
+        return self

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -15,6 +15,7 @@ from stac_pydantic.version import STAC_VERSION
 from starlette.responses import Response
 
 from stac_fastapi.types import stac
+from stac_fastapi.types.access_policy import AccessPolicy
 from stac_fastapi.types.config import ApiSettings
 from stac_fastapi.types.conformance import BASE_CONFORMANCE_CLASSES
 from stac_fastapi.types.extension import ApiExtension
@@ -204,6 +205,44 @@ class BaseTransactionsClient(abc.ABC):
         """
         ...
 
+    @abc.abstractmethod
+    def update_collection_access_policy(
+        self, cat_path: str, collection_id: str, access_policy: AccessPolicy, workspace: str, **kwargs
+    ) -> Optional[Union[stac.Collection, Response]]:
+        """Perform an update of the access policy for a collection.
+
+        Called with `PUT /catalogs/{cat_path:path}/catalogs/collections/{collection_id}/access-policy`. It is expected that this
+        collection already exists.  The update should perform any necessary updates to the collection access-policy.  
+        Partial updates are not supported by the transactions extension.
+
+        Args:
+            collection_id: id of the existing collection to be updated
+            access_policy: the access_policy to apply to the collection.
+
+        Returns:
+            The updated collection.
+        """
+        ...
+
+    @abc.abstractmethod
+    def update_catalog_access_policy(
+        self, cat_path: str, access_policy: AccessPolicy, workspace: str, **kwargs
+    ) -> Optional[Union[stac.Collection, Response]]:
+        """Perform an update of the access policy for a catalog.
+
+        Called with `PUT /catalogs/{cat_path:path}/catalogs/{catalog_id}/access-policy`. It is expected that this
+        catalog already exists.  The update should perform any necessary updates to the catalog access-policy.  
+        Partial updates are not supported by the transactions extension.
+
+        Args:
+            cat_path: path of the existing catalog to be updated
+            access_policy: the access_policy to apply to the catalog.
+
+        Returns:
+            The updated catalog.
+        """
+        ...
+
 
 @attr.s  # type:ignore
 class AsyncBaseTransactionsClient(abc.ABC):
@@ -368,6 +407,44 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
         Returns:
             The deleted catalog.
+        """
+        ...
+
+    @abc.abstractmethod
+    def update_collection_access_policy(
+        self, cat_path: str, collection_id: str, access_policy: AccessPolicy, workspace: str, **kwargs
+    ) -> Optional[Union[stac.Collection, Response]]:
+        """Perform an update of the access policy for a collection.
+
+        Called with `PUT /catalogs/{cat_path:path}/catalogs/collections/{collection_id}/access-policy`. It is expected that this
+        collection already exists.  The update should perform any necessary updates to the collection access-policy.  
+        Partial updates are not supported by the transactions extension.
+
+        Args:
+            collection_id: id of the existing collection to be updated
+            access_policy: the access_policy to apply to the collection.
+
+        Returns:
+            The updated collection.
+        """
+        ...
+
+    @abc.abstractmethod
+    def update_catalog_access_policy(
+        self, cat_path: str, access_policy: AccessPolicy, workspace: str, **kwargs
+    ) -> Optional[Union[stac.Collection, Response]]:
+        """Perform an update of the access policy for a catalog.
+
+        Called with `PUT /catalogs/{cat_path:path}/catalogs/{catalog_id}/access-policy`. It is expected that this
+        catalog already exists.  The update should perform any necessary updates to the catalog access-policy.  
+        Partial updates are not supported by the transactions extension.
+
+        Args:
+            cat_path: path of the existing catalog to be updated
+            access_policy: the access_policy to apply to the catalog.
+
+        Returns:
+            The updated catalog.
         """
         ...
 

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -747,7 +747,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_catalog(self, cat_path: str, **kwargs) -> stac.Catalog:
+    def get_catalog(self, cat_path: str, catalog_id: str, **kwargs) -> stac.Catalog:
         """Get catalog by id.
 
         Called with `GET /catalogs/{cat_path}`.
@@ -1009,7 +1009,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_catalog(self, cat_path: str, **kwargs) -> stac.Catalog:
+    def get_catalog(self, cat_path: str, catalog_id: str, **kwargs) -> stac.Catalog:
         """Get catalog by id.
 
         Called with `GET /catalogs/{cat_path}`.

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -66,18 +66,20 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def update_item(
-        self, cat_path: str, collection_id: str, item_id: str, item: Item, **kwargs
+        self, cat_path: str, collection_id: str, item_id: str, item: Item, workspace: str, **kwargs
     ) -> Optional[Union[stac.Item, Response]]:
         """Perform a complete update on an existing item.
 
-        Called with `PUT /collections/{collection_id}/items`. It is expected
+        Called with `PUT /catalogs/{cat_path}/collections/{collection_id}/items`. It is expected
         that this item already exists.  The update should do a diff against the
         saved item and perform any necessary updates.  Partial updates are not
         supported by the transactions extension.
 
         Args:
+            cat_path: path of the existing catalog containing the parent collection
             item: the item (must be complete)
             collection_id: the id of the collection from the resource path
+            workspace: the requesting workspace.
 
         Returns:
             The updated item.
@@ -86,15 +88,17 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def delete_item(
-        self, cat_path: str, item_id: str, collection_id: str, **kwargs
+        self, cat_path: str, item_id: str, collection_id: str, workspace: str, **kwargs
     ) -> Optional[Union[stac.Item, Response]]:
         """Delete an item from a collection.
 
-        Called with `DELETE /collections/{collection_id}/items/{item_id}`
+        Called with `DELETE /catalogs/{cat_path}/collections/{collection_id}/items/{item_id}`
 
         Args:
+            cat_path: path of the existing catalog containing the parent collection.
             item_id: id of the item.
             collection_id: id of the collection.
+            workspace: the requesting workspace.
 
         Returns:
             The deleted item.
@@ -107,10 +111,12 @@ class BaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Collection, Response]]:
         """Create a new collection.
 
-        Called with `POST /collections`.
+        Called with `POST /catalogs/{cat_path}/collections`.
 
         Args:
+            cat_path: path of the existing catalog containing the collection
             collection: the collection
+            workspace: the requesting workspace
 
         Returns:
             The collection that was created.
@@ -123,14 +129,16 @@ class BaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Collection, Response]]:
         """Perform a complete update on an existing collection.
 
-        Called with `PUT /collections/{collection_id}`. It is expected that this
+        Called with `PUT /catalogs/{cat_path}/collections/{collection_id}`. It is expected that this
         collection already exists.  The update should do a diff against the saved
         collection and perform any necessary updates.  Partial updates are not
         supported by the transactions extension.
 
         Args:
+            cat_path: path of the existing catalog containing the collection
             collection_id: id of the existing collection to be updated
             collection: the updated collection (must be complete)
+            workspace: the requesting workspace
 
         Returns:
             The updated collection.
@@ -143,10 +151,12 @@ class BaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Collection, Response]]:
         """Delete a collection.
 
-        Called with `DELETE /collections/{collection_id}`
+        Called with `DELETE /catalogs/{cat_path}/collections/{collection_id}`
 
         Args:
+            cat_path: path of the existing catalog containing the collection
             collection_id: id of the collection.
+            workspace: the requesting workspace.
 
         Returns:
             The deleted collection.
@@ -159,10 +169,12 @@ class BaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Catalog, Response]]:
         """Create a new catalog.
 
-        Called with `POST /catalogs`.
+        Called with `POST /catalogs/{cat_path}/catalogs`.
 
         Args:
             catalog: the catalog
+            cat_path: path of the existing catalog containing the catalog, can be "root" for top-level catalogs
+            workspace: the requesting workspace.
 
         Returns:
             The catalog that was created.
@@ -175,14 +187,16 @@ class BaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Catalog, Response]]:
         """Perform a complete update on an existing catalog.
 
-        Called with `PUT /catalogs/{catalog_id}`. It is expected that this
+        Called with `PUT /catalogs/{cat_path}`. It is expected that this
         catalog already exists.  The update should do a diff against the saved
         catalog and perform any necessary updates.  Partial updates are not
         supported by the transactions extension.
 
         Args:
+            cat_path: path of the existing catalog containing the catalog
             catalog_id: id of the existing catalog to be updated
             catalog: the updated catalog (must be complete)
+            workspace: the requesting workspace.
 
         Returns:
             The updated catalog.
@@ -195,10 +209,11 @@ class BaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Catalog, Response]]:
         """Delete a catalog.
 
-        Called with `DELETE /catalogs/{catalog_id}`
+        Called with `DELETE /catalogs/{cat_path}`
 
         Args:
-            catalog_id: id of the catalog.
+            cat_path: path of the catalog.
+            workspace: the requesting workspace.
 
         Returns:
             The deleted catalog.
@@ -211,13 +226,15 @@ class BaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Collection, Response]]:
         """Perform an update of the access policy for a collection.
 
-        Called with `PUT /catalogs/{cat_path:path}/catalogs/collections/{collection_id}/access-policy`. It is expected that this
+        Called with `PUT /catalogs/{cat_path}/catalogs/collections/{collection_id}/access-policy`. It is expected that this
         collection already exists.  The update should perform any necessary updates to the collection access-policy.  
         Partial updates are not supported by the transactions extension.
 
         Args:
+            cat_path: path of the existing catalog containing the collection
             collection_id: id of the existing collection to be updated
             access_policy: the access_policy to apply to the collection.
+            workspace: the requesting workspace.
 
         Returns:
             The updated collection.
@@ -230,13 +247,14 @@ class BaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Collection, Response]]:
         """Perform an update of the access policy for a catalog.
 
-        Called with `PUT /catalogs/{cat_path:path}/catalogs/{catalog_id}/access-policy`. It is expected that this
+        Called with `PUT /catalogs/{cat_path}/catalogs/{catalog_id}/access-policy`. It is expected that this
         catalog already exists.  The update should perform any necessary updates to the catalog access-policy.  
         Partial updates are not supported by the transactions extension.
 
         Args:
             cat_path: path of the existing catalog to be updated
             access_policy: the access_policy to apply to the catalog.
+            workspace: the requesting workspace.
 
         Returns:
             The updated catalog.
@@ -259,11 +277,13 @@ class AsyncBaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Item, Response, None]]:
         """Create a new item.
 
-        Called with `POST /collections/{collection_id}/items`.
+        Called with `POST /catalogs/{cat_path}/collections/{collection_id}/items`.
 
         Args:
+            cat_path: path of the existing catalog containing the parent collection
             item: the item or item collection
             collection_id: the id of the collection from the resource path
+            workspace: the requesting workspace.
 
         Returns:
             The item that was created or None if item collection.
@@ -276,13 +296,17 @@ class AsyncBaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Item, Response]]:
         """Perform a complete update on an existing item.
 
-        Called with `PUT /collections/{collection_id}/items`. It is expected
+        Called with `PUT /catalogs/{cat_path}/collections/{collection_id}/items`. It is expected
         that this item already exists.  The update should do a diff against the
-        saved item and perform any necessary updates.  Partial updates are not
+        saved item and perform any necessary updates. Partial updates are not
         supported by the transactions extension.
 
         Args:
+            cat_path: path of the existing catalog containing the parent collection
+            collection_id: the id of the collection from the resource path
+            item_id: id of the existing item to be updated
             item: the item (must be complete)
+            workspace: the requesting workspace.
 
         Returns:
             The updated item.
@@ -295,11 +319,13 @@ class AsyncBaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Item, Response]]:
         """Delete an item from a collection.
 
-        Called with `DELETE /collections/{collection_id}/items/{item_id}`
+        Called with `DELETE /catalogs/{cat_path}/collections/{collection_id}/items/{item_id}`
 
         Args:
+            cat_path: path of the existing catalog containing the parent collection
             item_id: id of the item.
             collection_id: id of the collection.
+            workspace: the requesting workspace.
 
         Returns:
             The deleted item.
@@ -312,10 +338,12 @@ class AsyncBaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Collection, Response]]:
         """Create a new collection.
 
-        Called with `POST /collections`.
+        Called with `POST /catalogs/{cat_path}/collections`.
 
         Args:
+            cat_path: path of the existing catalog containing the collection
             collection: the collection
+            workspace: the requesting workspace.
 
         Returns:
             The collection that was created.
@@ -328,14 +356,16 @@ class AsyncBaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Collection, Response]]:
         """Perform a complete update on an existing collection.
 
-        Called with `PUT /collections/{collection_id}`. It is expected that this item
+        Called with `PUT /catalogs/{cat_path}/collections/{collection_id}`. It is expected that this item
         already exists.  The update should do a diff against the saved collection and
         perform any necessary updates.  Partial updates are not supported by the
         transactions extension.
 
         Args:
+            cat_path: path of the existing catalog containing the collection
             collection_id: id of the existing collection to be updated
             collection: the updated collection (must be complete)
+            workspace: the requesting workspace.
 
         Returns:
             The updated collection.
@@ -348,10 +378,12 @@ class AsyncBaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Collection, Response]]:
         """Delete a collection.
 
-        Called with `DELETE /collections/{collection_id}`
+        Called with `DELETE /catalogs/{cat_path}/collections/{collection_id}`
 
         Args:
+            cat_path: path of the existing catalog containing the collection
             collection_id: id of the collection.
+            workspace: the requesting workspace.
 
         Returns:
             The deleted collection.
@@ -364,10 +396,12 @@ class AsyncBaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Catalog, Response]]:
         """Create a new catalog.
 
-        Called with `POST /catalogs`.
+        Called with `POST /catalogs/{cat_path}/catalogs`.
 
         Args:
+            cat_path: path of the existing catalog containing the catalog
             catalog: the catalog
+            workspace: the requesting workspace.
 
         Returns:
             The catalog that was created.
@@ -380,14 +414,15 @@ class AsyncBaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Catalog, Response]]:
         """Perform a complete update on an existing catalog.
 
-        Called with `PUT /catalogs/{catalog_id}`. It is expected that this item
+        Called with `PUT /catalogs/{cat_path}`. It is expected that this item
         already exists.  The update should do a diff against the saved catalog and
         perform any necessary updates.  Partial updates are not supported by the
         transactions extension.
 
         Args:
-            catalog_id: id of the existing catalog to be updated
+            cat_path: path of the existing catalog containing the catalog
             catalog: the updated catalog (must be complete)
+            workspace: the requesting workspace.
 
         Returns:
             The updated catalog.
@@ -400,10 +435,11 @@ class AsyncBaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Catalog, Response]]:
         """Delete a catalog.
 
-        Called with `DELETE /catalogs/{catalog_id}`
+        Called with `DELETE /catalogs/{cat_path}`
 
         Args:
-            catalog_id: id of the catalog.
+            cat_path: path of the catalog.
+            workspace: the requesting workspace.
 
         Returns:
             The deleted catalog.
@@ -416,13 +452,15 @@ class AsyncBaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Collection, Response]]:
         """Perform an update of the access policy for a collection.
 
-        Called with `PUT /catalogs/{cat_path:path}/catalogs/collections/{collection_id}/access-policy`. It is expected that this
+        Called with `PUT /catalogs/{cat_path}/collections/{collection_id}/access-policy`. It is expected that this
         collection already exists.  The update should perform any necessary updates to the collection access-policy.  
         Partial updates are not supported by the transactions extension.
 
         Args:
+            cat_path: path of the existing catalog containing the collection
             collection_id: id of the existing collection to be updated
             access_policy: the access_policy to apply to the collection.
+            workspace: the requesting workspace.
 
         Returns:
             The updated collection.
@@ -435,13 +473,13 @@ class AsyncBaseTransactionsClient(abc.ABC):
     ) -> Optional[Union[stac.Collection, Response]]:
         """Perform an update of the access policy for a catalog.
 
-        Called with `PUT /catalogs/{cat_path:path}/catalogs/{catalog_id}/access-policy`. It is expected that this
+        Called with `PUT /catalogs/{cat_path}/access-policy`. It is expected that this
         catalog already exists.  The update should perform any necessary updates to the catalog access-policy.  
-        Partial updates are not supported by the transactions extension.
 
         Args:
             cat_path: path of the existing catalog to be updated
             access_policy: the access_policy to apply to the catalog.
+            workspace: the requesting workspace.
 
         Returns:
             The updated catalog.
@@ -660,14 +698,16 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
 
     @abc.abstractmethod
     def post_search(
-        self, search_request: BaseSearchPostRequest, cat_path: str = None, **kwargs
+        self, search_request: BaseSearchPostRequest, workspaces: Optional[List[str]], cat_path: str = None, **kwargs
     ) -> stac.ItemCollection:
         """Cross catalog search (POST).
 
-        Called with `POST /search`.
+        Called with `POST /catalogs/{cat_path}/search`.
 
         Args:
             search_request: search request parameters.
+            workspaces: list of workspaces to search.
+            cat_path: path of the catalog to search.
 
         Returns:
             ItemCollection containing items which match the search criteria.
@@ -688,7 +728,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
     ) -> stac.ItemCollection:
         """Cross catalog search (GET).
 
-        Called with `GET /search`.
+        Called with `GET /catalogs/{cat_path}/search`.
 
         Returns:
             ItemCollection containing items which match the search criteria.
@@ -696,14 +736,16 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_item(self, cat_path: str, item_id: str, collection_id: str, **kwargs) -> stac.Item:
+    def get_item(self, cat_path: str, item_id: str, collection_id: str, workspaces: Optional[List[str]], **kwargs) -> stac.Item:
         """Get item by id.
 
-        Called with `GET /collections/{collection_id}/items/{item_id}`.
+        Called with `GET /catalogs/{cat_path}/collections/{collection_id}/items/{item_id}`.
 
         Args:
+            cat_path: Path of the catalog.
             item_id: Id of the item.
             collection_id: Id of the collection.
+            workspaces: list of workspaces to search.
 
         Returns:
             Item.
@@ -722,13 +764,15 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_collection(self, cat_path: str, collection_id: str, **kwargs) -> stac.Collection:
+    def get_collection(self, cat_path: str, collection_id: str, workspaces: Optional[List[str]], **kwargs) -> stac.Collection:
         """Get collection by id.
 
-        Called with `GET /collections/{collection_id}`.
+        Called with `GET /catalogs/{cat_path}/collections/{collection_id}`.
 
         Args:
+            cat_path: Path of the catalog.
             collection_id: Id of the collection.
+            workspaces: list of workspaces to search.
 
         Returns:
             Collection.
@@ -750,10 +794,11 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
     def get_catalog(self, cat_path: str, catalog_id: str, **kwargs) -> stac.Catalog:
         """Get catalog by id.
 
-        Called with `GET /catalogs/{cat_path}`.
+        Called with `GET /catalogs/{cat_path}/catalogs/{catalog_id}`.
 
         Args:
             cat_path: Path of the catalog.
+            catalog_id: Id of the catalog.
 
         Returns:
             Catalog.
@@ -765,6 +810,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         self,
         cat_path: str,
         collection_id: str,
+        workspaces: Optional[List[str]], 
         bbox: Optional[BBox] = None,
         datetime: Optional[DateTimeType] = None,
         limit: int = 10,
@@ -773,10 +819,14 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
     ) -> stac.ItemCollection:
         """Get all items from a specific collection.
 
-        Called with `GET /collections/{collection_id}/items`
+        Called with `GET /catalogs/{cat_path}/collections/{collection_id}/items`
 
         Args:
+            cat_path: Path of the catalog.
             collection_id: id of the collection.
+            workspaces: list of workspaces to search.
+            bbox: bounding box to filter items.
+            datetime: datetime to filter items.
             limit: number of items to return.
             token: pagination token.
 
@@ -958,14 +1008,16 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def get_item(self, cat_path: str, item_id: str, collection_id: str, **kwargs) -> stac.Item:
+    async def get_item(self, cat_path: str, item_id: str, collection_id: str, workspaces: Optional[List[str]], **kwargs) -> stac.Item:
         """Get item by id.
 
-        Called with `GET /collections/{collection_id}/items/{item_id}`.
+        Called with `GET /catalogs/{cat_path}/collections/{collection_id}/items/{item_id}`.
 
         Args:
+            cat_path: Path of the catalog.
             item_id: Id of the item.
             collection_id: Id of the collection.
+            workspaces: list of workspaces to search.
 
         Returns:
             Item.
@@ -984,13 +1036,15 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def get_collection(self, cat_path: str, collection_id: str, **kwargs) -> stac.Collection:
+    async def get_collection(self, cat_path: str, collection_id: str, workspaces: Optional[List[str]], **kwargs) -> stac.Collection:
         """Get collection by id.
 
-        Called with `GET /collections/{collection_id}`.
+        Called with `GET /catalogs/{cat_path}/collections/{collection_id}`.
 
         Args:
+            cat_path: Path of the catalog.
             collection_id: Id of the collection.
+            workspaces: list of workspaces to search.
 
         Returns:
             Collection.
@@ -1009,13 +1063,15 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_catalog(self, cat_path: str, catalog_id: str, **kwargs) -> stac.Catalog:
+    def get_catalog(self, cat_path: str, catalog_id: str, workspaces: Optional[List[str]], **kwargs) -> stac.Catalog:
         """Get catalog by id.
 
-        Called with `GET /catalogs/{cat_path}`.
+        Called with `GET /catalogs/{cat_path}/catalogs/{catalog_id}`.
 
         Args:
             cat_path: Path of the catalog.
+            catalog_id: Id of the catalog.
+            workspaces: list of workspaces to search.
 
         Returns:
             Catalog.
@@ -1027,6 +1083,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         self,
         cat_path: str,
         collection_id: str,
+        workspaces: Optional[List[str]], 
         bbox: Optional[BBox] = None,
         datetime: Optional[DateTimeType] = None,
         limit: int = 10,
@@ -1035,10 +1092,14 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
     ) -> stac.ItemCollection:
         """Get all items from a specific collection.
 
-        Called with `GET /collections/{collection_id}/items`
+        Called with `GET /catalogs/{cat_path}/collections/{collection_id}/items`
 
         Args:
+            cat_path: Path of the catalog.
             collection_id: id of the collection.
+            workspaces: list of workspaces to search.
+            bbox: bounding box to filter items.
+            datetime: datetime to filter items.
             limit: number of items to return.
             token: pagination token.
 

--- a/stac_fastapi/types/stac_fastapi/types/errors.py
+++ b/stac_fastapi/types/stac_fastapi/types/errors.py
@@ -39,11 +39,3 @@ class InvalidQueryParameter(StacApiError):
     """
 
     pass
-
-class UnauthorizedError(StacApiError):
-    """Error for unauthorized access to a resource."""
-    pass
-
-class UnauthenticatedError(StacApiError):
-    """Error for unauthenticated access to a resource."""
-    pass

--- a/stac_fastapi/types/stac_fastapi/types/errors.py
+++ b/stac_fastapi/types/stac_fastapi/types/errors.py
@@ -39,3 +39,11 @@ class InvalidQueryParameter(StacApiError):
     """
 
     pass
+
+class UnauthorizedError(StacApiError):
+    """Error for unauthorized access to a resource."""
+    pass
+
+class UnauthenticatedError(StacApiError):
+    """Error for unauthenticated access to a resource."""
+    pass

--- a/stac_fastapi/types/stac_fastapi/types/links.py
+++ b/stac_fastapi/types/stac_fastapi/types/links.py
@@ -10,7 +10,16 @@ from stac_pydantic.shared import MimeTypes
 # These can be inferred from the item/collection so they aren't included in the database
 # Instead they are dynamically generated when querying the database using the
 # classes defined below
-INFERRED_LINK_RELS = ["self", "item", "parent", "collection", "root", "items"]
+INFERRED_LINK_RELS = [
+    "self",
+    "item",
+    "parent",
+    "collection",
+    "root",
+    "items",
+    "data",
+    "child",
+]
 
 
 def filter_links(links: List[Dict]) -> List[Dict]:

--- a/stac_fastapi/types/stac_fastapi/types/links.py
+++ b/stac_fastapi/types/stac_fastapi/types/links.py
@@ -30,6 +30,7 @@ def resolve_links(links: list, base_url: str) -> List[Dict]:
 class BaseLinks:
     """Create inferred links common to collections and items."""
 
+    catalog_path: str = attr.ib() # includes catalogs/
     collection_id: str = attr.ib()
     base_url: str = attr.ib()
 
@@ -47,7 +48,7 @@ class CollectionLinks(BaseLinks):
         return dict(
             rel=Relations.self,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
+            href=urljoin(self.base_url, f"{self.catalog_path}/collections/{self.collection_id}"),
         )
 
     def parent(self) -> Dict[str, Any]:
@@ -59,7 +60,7 @@ class CollectionLinks(BaseLinks):
         return dict(
             rel="items",
             type=MimeTypes.geojson,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}/items"),
+            href=urljoin(self.base_url, f"{self.catalog_path}/collections/{self.collection_id}/items"),
         )
 
     def create_links(self) -> List[Dict[str, Any]]:
@@ -80,7 +81,7 @@ class ItemLinks(BaseLinks):
             type=MimeTypes.geojson,
             href=urljoin(
                 self.base_url,
-                f"collections/{self.collection_id}/items/{self.item_id}",
+                f"{self.catalog_path}/collections/{self.collection_id}/items/{self.item_id}",
             ),
         )
 
@@ -89,7 +90,7 @@ class ItemLinks(BaseLinks):
         return dict(
             rel=Relations.parent,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
+            href=urljoin(self.base_url, f"{self.catalog_path}/collections/{self.collection_id}"),
         )
 
     def collection(self) -> Dict[str, Any]:
@@ -97,7 +98,7 @@ class ItemLinks(BaseLinks):
         return dict(
             rel=Relations.collection,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
+            href=urljoin(self.base_url, f"{self.catalog_path}/collections/{self.collection_id}"),
         )
 
     def create_links(self) -> List[Dict[str, Any]]:
@@ -109,3 +110,31 @@ class ItemLinks(BaseLinks):
             self.root(),
         ]
         return links
+    
+@attr.s
+class CatalogLinks(BaseLinks):
+    """Create inferred links specific to catalogs."""
+
+    def self(self) -> Dict[str, Any]:
+        """Create the `self` link."""
+        return dict(
+            rel=Relations.self,
+            type=MimeTypes.json,
+            href=urljoin(self.base_url, f"{self.catalog_path}"),
+        )
+
+    def parent(self) -> Dict[str, Any]:
+        """Create the `parent` link."""
+        return dict(rel=Relations.parent, type=MimeTypes.json, href=self.base_url)
+
+    def collections(self) -> Dict[str, Any]:
+        """Create the `collections` link."""
+        return dict(
+            rel="items",
+            type=MimeTypes.geojson,
+            href=urljoin(self.base_url, f"{self.catalog_path}/collections"),
+        )
+
+    def create_links(self) -> List[Dict[str, Any]]:
+        """Return all inferred links."""
+        return [self.self(), self.parent(), self.collections(), self.root()]

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -120,7 +120,7 @@ class APIRequest:
 class BaseSearchGetRequest(APIRequest):
     """Base arguments for GET Request."""
 
-    cat_path: Annotated[str, Path(description="Catalog path", regex=r"^(catalogs/[^/]+)(/catalogs/[^/]+)*")] = attr.ib()
+    cat_path: Annotated[str, Path(description="Catalog path", regex=r"^([^/]+)(/catalogs/[^/]+)*$")] = attr.ib()
     collections: Optional[List[str]] = attr.ib(
         default=None, converter=_collection_converter
     )

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -1,11 +1,11 @@
 """stac_fastapi.types.search module.
 
 """
-from datetime import datetime as dt
+
 from typing import Dict, List, Optional, Union
 
 import attr
-from fastapi import Query
+from fastapi import Query, Path, Body
 from pydantic import Field, PositiveInt
 from pydantic.functional_validators import AfterValidator
 from stac_pydantic.api import Search
@@ -83,29 +83,27 @@ def _bbox_converter(
     return str2bbox(val)
 
 
-def _validate_datetime(instance, attribute, value):
-    """Validate Datetime."""
-    _ = str_to_interval(value)
+def _datetime_converter(
+    val: Annotated[
+        Optional[str],
+        Query(
+            description="""Only return items that have a temporal property that intersects this value.\n
+Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.""",  # noqa: E501
+            openapi_examples={
+                "datetime": {"value": "2018-02-12T23:20:50Z"},
+                "closed-interval": {"value": "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"},
+                "open-interval-from": {"value": "2018-02-12T00:00:00Z/.."},
+                "open-interval-to": {"value": "../2018-03-18T12:31:12Z"},
+            },
+        ),
+    ] = None,
+):
+    return str_to_interval(val)
 
 
 # Be careful: https://github.com/samuelcolvin/pydantic/issues/1423#issuecomment-642797287
 NumType = Union[float, int]
 Limit = Annotated[PositiveInt, AfterValidator(crop)]
-
-
-DateTimeQueryType = Annotated[
-    Optional[str],
-    Query(
-        description="""Only return items that have a temporal property that intersects this value.\n
-Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.""",  # noqa: E501
-        openapi_examples={
-            "datetime": {"value": "2018-02-12T23:20:50Z"},
-            "closed-interval": {"value": "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"},
-            "open-interval-from": {"value": "2018-02-12T00:00:00Z/.."},
-            "open-interval-to": {"value": "../2018-03-18T12:31:12Z"},
-        },
-    ),
-]
 
 
 @attr.s
@@ -119,36 +117,73 @@ class APIRequest:
 
 
 @attr.s
-class DatetimeMixin:
-    """Datetime Mixin."""
+class BaseSearchGetRequest(APIRequest):
+    """Base arguments for GET Request."""
 
-    datetime: DateTimeQueryType = attr.ib(default=None, validator=_validate_datetime)
-
-    def parse_datetime(self) -> Optional[DateTimeType]:
-        """Return Datetime objects."""
-        return str_to_interval(self.datetime)
-
-    @property
-    def start_date(self) -> Optional[dt]:
-        """Start Date."""
-        parsed = self.parse_datetime()
-        if parsed is None:
-            return None
-
-        return parsed[0] if isinstance(parsed, tuple) else parsed
-
-    @property
-    def end_date(self) -> Optional[dt]:
-        """End Date."""
-        parsed = self.parse_datetime()
-        if parsed is None:
-            return None
-
-        return parsed[1] if isinstance(parsed, tuple) else None
+    cat_path: Annotated[str, Path(description="Catalog path", regex=r"^(catalogs/[^/]+)(/catalogs/[^/]+)*")] = attr.ib()
+    collections: Optional[List[str]] = attr.ib(
+        default=None, converter=_collection_converter
+    )
+    ids: Optional[List[str]] = attr.ib(default=None, converter=_ids_converter)
+    bbox: Optional[BBox] = attr.ib(default=None, converter=_bbox_converter)
+    intersects: Annotated[
+        Optional[str],
+        Query(
+            description="""Only return items intersecting this GeoJSON Geometry. Mutually exclusive with **bbox**. \n
+*Remember to URL encode the GeoJSON geometry when using GET request*.""",  # noqa: E501
+            openapi_examples={
+                "madrid": {
+                    "value": {
+                        "type": "Feature",
+                        "properties": {},
+                        "geometry": {
+                            "coordinates": [
+                                [
+                                    [-3.8549260500072933, 40.54923557897152],
+                                    [-3.8549260500072933, 40.29428000041938],
+                                    [-3.516597069715033, 40.29428000041938],
+                                    [-3.516597069715033, 40.54923557897152],
+                                    [-3.8549260500072933, 40.54923557897152],
+                                ]
+                            ],
+                            "type": "Polygon",
+                        },
+                    },
+                },
+                "new-york": {
+                    "value": {
+                        "type": "Feature",
+                        "properties": {},
+                        "geometry": {
+                            "coordinates": [
+                                [
+                                    [-74.50117532354284, 41.128266394414055],
+                                    [-74.50117532354284, 40.35633909727355],
+                                    [-73.46713183168603, 40.35633909727355],
+                                    [-73.46713183168603, 41.128266394414055],
+                                    [-74.50117532354284, 41.128266394414055],
+                                ]
+                            ],
+                            "type": "Polygon",
+                        },
+                    },
+                },
+            },
+        ),
+    ] = attr.ib(default=None)
+    datetime: Optional[DateTimeType] = attr.ib(
+        default=None, converter=_datetime_converter
+    )
+    limit: Annotated[
+        Optional[Limit],
+        Query(
+            description="Limits the number of results that are included in each page of the response (capped to 10_000)."  # noqa: E501
+        ),
+    ] = attr.ib(default=10)
 
 
 @attr.s
-class BaseSearchGetRequest(APIRequest, DatetimeMixin):
+class BaseSearchAllGetRequest(APIRequest):
     """Base arguments for GET Request."""
 
     collections: Optional[List[str]] = attr.ib(
@@ -201,7 +236,9 @@ class BaseSearchGetRequest(APIRequest, DatetimeMixin):
             },
         ),
     ] = attr.ib(default=None)
-    datetime: DateTimeQueryType = attr.ib(default=None, validator=_validate_datetime)
+    datetime: Optional[DateTimeType] = attr.ib(
+        default=None, converter=_datetime_converter
+    )
     limit: Annotated[
         Optional[Limit],
         Query(

--- a/stac_fastapi/types/stac_fastapi/types/stac.py
+++ b/stac_fastapi/types/stac_fastapi/types/stac.py
@@ -50,6 +50,7 @@ class Collection(Catalog, total=False):
     extent: Dict[str, Any]
     summaries: Dict[str, Any]
     assets: Dict[str, Any]
+    renders: Dict[str, Any]
 
 
 class Item(TypedDict, total=False):

--- a/stac_fastapi/types/stac_fastapi/types/stac.py
+++ b/stac_fastapi/types/stac_fastapi/types/stac.py
@@ -86,3 +86,14 @@ class Collections(TypedDict, total=False):
     links: List[Dict[str, Any]]
     numberMatched: Optional[int] = None
     numberReturned: Optional[int] = None
+
+
+class Catalogs(TypedDict, total=False):
+    """All catalogs endpoint.
+    https://github.com/radiantearth/stac-api-spec/tree/master/catalogs
+    """
+
+    catalogs: List[Catalog]
+    links: List[Dict[str, Any]]
+    numberMatched: Optional[int] = None
+    numberReturned: Optional[int] = None


### PR DESCRIPTION
## Update for EODHP Functionality
- Based on a more up to date STAC-FastApi release
- Added nested catalogs
- Reduced number of indices to 3, one for catalogs, one for collections and one for items
- Adding `cat_path` to any endpoints that required catalog specific functionality, e.g. `/collections` and `/search`
- Updated collection-search extension
- Added auth header usage
- Added access-control functionality to restrict access to private catalogs and allow publishing of catalogs and collections
- I have not yet updated the unit tests, as this will be a lot of work and we first need to get this working on test to improve usability for app-devs