### PR TITLE
Bugfix/eodhp 1105 fix trailing slash redirect

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -18,7 +18,7 @@ from typing_extensions import Annotated
 
 
 from stac_fastapi.api.errors import DEFAULT_STATUS_CODES, add_exception_handlers
-from stac_fastapi.api.middleware import CORSMiddleware, ProxyHeaderMiddleware
+from stac_fastapi.api.middleware import ProxyHeaderMiddleware, TrailingSlashRedirectMiddleware
 from stac_fastapi.api.models import (
     APIRequest,
     BaseCatalogUri,
@@ -132,6 +132,7 @@ class StacApi:
             lambda: [
                 Middleware(BrotliMiddleware),
                 Middleware(ProxyHeaderMiddleware),
+                Middleware(TrailingSlashRedirectMiddleware),
             ]
         )
     )

--- a/stac_fastapi/api/stac_fastapi/api/middleware.py
+++ b/stac_fastapi/api/stac_fastapi/api/middleware.py
@@ -142,7 +142,11 @@ class TrailingSlashRedirectMiddleware(BaseHTTPMiddleware):
         print("REDIRECT MIDDLEWARE")
         print(request.url)
         print(request.url.path)
-        if request.url.path != '/' and request.url.path.endswith('/'):
-            return RedirectResponse(url=request.url.path.rstrip('/'))
+        root_path = request.scope.get("root_path", "")
+        full_path = root_path + request.url.path
+        print(f"Full Path: {full_path}")
+        if full_path != '/' and full_path.endswith('/'):
+            new_url = request.url.replace(path=full_path.rstrip('/'))
+            return RedirectResponse(url=str(new_url))
         response = await call_next(request)
         return response

--- a/stac_fastapi/api/stac_fastapi/api/middleware.py
+++ b/stac_fastapi/api/stac_fastapi/api/middleware.py
@@ -6,7 +6,9 @@ import typing
 from http.client import HTTP_PORT, HTTPS_PORT
 from typing import List, Tuple
 
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.cors import CORSMiddleware as _CORSMiddleware
+from starlette.responses import RedirectResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 
@@ -132,3 +134,12 @@ class ProxyHeaderMiddleware:
             for name, value in scope["headers"]
             if name.decode() != header_name
         ] + [(str.encode(header_name), str.encode(new_value))]
+
+
+# New class to handle trailing slash redirects
+class TrailingSlashRedirectMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        if request.url.path != '/' and request.url.path.endswith('/'):
+            return RedirectResponse(url=request.url.path.rstrip('/'))
+        response = await call_next(request)
+        return response

--- a/stac_fastapi/api/stac_fastapi/api/middleware.py
+++ b/stac_fastapi/api/stac_fastapi/api/middleware.py
@@ -140,8 +140,9 @@ class ProxyHeaderMiddleware:
 class TrailingSlashRedirectMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         print("REDIRECT MIDDLEWARE")
+        print(request.url)
+        print(request.url.path)
         if request.url.path != '/' and request.url.path.endswith('/'):
-            new_url = request.url_for(request.scope["endpoint"]).rstrip('/')
-            return RedirectResponse(url=new_url)
+            return RedirectResponse(url=request.url.path.rstrip('/'))
         response = await call_next(request)
         return response

--- a/stac_fastapi/api/stac_fastapi/api/middleware.py
+++ b/stac_fastapi/api/stac_fastapi/api/middleware.py
@@ -139,12 +139,8 @@ class ProxyHeaderMiddleware:
 # New class to handle trailing slash redirects
 class TrailingSlashRedirectMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
-        print("REDIRECT MIDDLEWARE")
-        print(request.url)
-        print(request.url.path)
         root_path = request.scope.get("root_path", "")
         full_path = root_path + request.url.path
-        print(f"Full Path: {full_path}")
         if full_path != '/' and full_path.endswith('/'):
             new_url = request.url.replace(path=full_path.rstrip('/'))
             return RedirectResponse(url=str(new_url))

--- a/stac_fastapi/api/stac_fastapi/api/middleware.py
+++ b/stac_fastapi/api/stac_fastapi/api/middleware.py
@@ -143,6 +143,6 @@ class TrailingSlashRedirectMiddleware(BaseHTTPMiddleware):
         full_path = root_path + request.url.path
         if full_path != '/' and full_path.endswith('/'):
             new_url = request.url.replace(path=full_path.rstrip('/'))
-            return RedirectResponse(url=str(new_url))
+            return RedirectResponse(url=str(new_url), status_code=308)
         response = await call_next(request)
         return response

--- a/stac_fastapi/api/stac_fastapi/api/middleware.py
+++ b/stac_fastapi/api/stac_fastapi/api/middleware.py
@@ -141,6 +141,7 @@ class TrailingSlashRedirectMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         print("REDIRECT MIDDLEWARE")
         if request.url.path != '/' and request.url.path.endswith('/'):
-            return RedirectResponse(url=request.url.path.rstrip('/'))
+            new_url = request.url_for(request.scope["endpoint"]).rstrip('/')
+            return RedirectResponse(url=new_url)
         response = await call_next(request)
         return response

--- a/stac_fastapi/api/stac_fastapi/api/middleware.py
+++ b/stac_fastapi/api/stac_fastapi/api/middleware.py
@@ -139,6 +139,7 @@ class ProxyHeaderMiddleware:
 # New class to handle trailing slash redirects
 class TrailingSlashRedirectMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
+        print("REDIRECT MIDDLEWARE")
         if request.url.path != '/' and request.url.path.endswith('/'):
             return RedirectResponse(url=request.url.path.rstrip('/'))
         response = await call_next(request)


### PR DESCRIPTION
## Add Middleware to Redirect for Trailing Slashes
- If trailing slash is included in path, remove and redirect to standard URL endpoint