### PR TITLE
Add check for url path

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/middleware.py
+++ b/stac_fastapi/api/stac_fastapi/api/middleware.py
@@ -141,7 +141,8 @@ class TrailingSlashRedirectMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         root_path = request.scope.get("root_path", "")
         full_path = root_path + request.url.path
-        if full_path != '/' and full_path.endswith('/'):
+        # Need to check path is not just "/" as well
+        if request.url.path != '/' and full_path.endswith('/'):
             new_url = request.url.replace(path=full_path.rstrip('/'))
             return RedirectResponse(url=str(new_url), status_code=308)
         response = await call_next(request)


### PR DESCRIPTION
## Quick fix to ensure the landing page is handled correctly
- the landing page is simply `/` which was causing issues with the check in the code as no redirect is required in this case
- We now check the `request.url.path` only for "/" to ensure we don't redirect for the landing page