### PR TITLE
Feature/remove workspaces token exchange and allow user service access

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -84,7 +84,6 @@ def extract_headers(
     headers = {}
     if credentials:
         # Exchange the token
-        logger.info(credentials.credentials)
         keycloak_token = credentials.credentials
         decoded_jwt = jwt.decode(
             keycloak_token,
@@ -92,13 +91,11 @@ def extract_headers(
             algorithms=["HS256"],
         )
         workspaces = decoded_jwt.get("workspaces", [])
-        user_services = decoded_jwt.get("user_services", None)
         logger.info(f"User is authenticated with workspaces: {workspaces}")
+
+        user_services = decoded_jwt.get("user_services", None)
         if user_services:
             logger.info(f"User has access to user service workspace: {user_services}")
-
-        # Append user_services to workspaces if it exists
-        if user_services:
             workspaces.append(user_services)
         
         # Add the workspaces to the headers

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -103,15 +103,19 @@ def extract_headers(
     headers = {}
     if credentials:
         # Exchange the token
-        keycloak_token = token_exchange(credentials.credentials, "workspaces")
+        keycloak_token = credentials.credentials
         decoded_jwt = jwt.decode(
             keycloak_token,
             options={"verify_signature": False},
             algorithms=["HS256"],
         )
         workspaces = decoded_jwt.get("workspaces", [])
+        user_services = decoded_jwt.get("user_services", None)
         logger.info(f"User is authenticated with workspaces: {workspaces}")
-        headers["X-Workspaces"] = workspaces
+        if user_services:
+            logger.info(f"User has access to user service workspace: {user_services}")
+        # Append user_services to workspaces if it exists
+        headers["X-Workspaces"] = workspaces.append(user_services) if user_services else workspaces
         headers["X-Authenticated"] = True
     else:
         logger.info("User is not authenticated")

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -84,6 +84,7 @@ def extract_headers(
     headers = {}
     if credentials:
         # Exchange the token
+        logger.info(credentials.credentials)
         keycloak_token = credentials.credentials
         decoded_jwt = jwt.decode(
             keycloak_token,

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -95,6 +95,7 @@ def extract_headers(
         logger.info(f"User is authenticated with workspaces: {workspaces}")
         if user_services:
             logger.info(f"User has access to user service workspace: {user_services}")
+
         # Append user_services to workspaces if it exists
         headers["X-Workspaces"] = workspaces.append(user_services) if user_services else workspaces
         headers["X-Authenticated"] = True

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -97,7 +97,11 @@ def extract_headers(
             logger.info(f"User has access to user service workspace: {user_services}")
 
         # Append user_services to workspaces if it exists
-        headers["X-Workspaces"] = workspaces.append(user_services) if user_services else workspaces
+        if user_services:
+            workspaces.append(user_services)
+        
+        # Add the workspaces to the headers
+        headers["X-Workspaces"] = workspaces
         headers["X-Authenticated"] = True
     else:
         logger.info("User is not authenticated")

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -69,25 +69,6 @@ def sync_to_async(func):
 # Define the OAuth2 scheme for Bearer token
 bearer_scheme = HTTPBearer(auto_error=False)
 
-def token_exchange(subject_token: str, scope: str = None) -> str:
-    payload = {
-        "client_id": CLIENT_ID,
-        "client_secret": CLIENT_SECRET,
-        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-        "subject_token": subject_token,
-        "scope": scope,
-    }
-    response = requests.post(
-        KEYCLOAK_URL,
-        data=payload,
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-    )
-
-    if not response.ok:
-        raise Exception(f"Error: {response.text}")
-
-    return response.json().get("access_token")
-
 # TODO: Also extract group information from the headers
 def extract_headers(
     credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -21,7 +21,7 @@ from starlette.status import HTTP_204_NO_CONTENT
 
 from stac_fastapi.api.models import APIRequest
 
-from stac_fastapi.api.settings import KEYCLOAK_BASE_URL, REALM, CLIENT_ID, CLIENT_SECRET, CACHE_CONTROL_CATALOGS_LIST, CACHE_CONTROL_HEADERS
+from stac_fastapi.api.settings import CACHE_CONTROL_CATALOGS_LIST, CACHE_CONTROL_HEADERS
 
 # Get the logger for this module
 logger = logging.getLogger(__name__)
@@ -37,8 +37,6 @@ console_handler.setFormatter(formatter)
 
 # Add the handler to the logger
 logger.addHandler(console_handler)
-
-KEYCLOAK_URL = f"{KEYCLOAK_BASE_URL}/realms/{REALM}/protocol/openid-connect/token"
 
 def _wrap_response(resp: Any, verb: str, url_path: str) -> Any:
     if resp is not None:

--- a/stac_fastapi/api/stac_fastapi/api/settings.py
+++ b/stac_fastapi/api/stac_fastapi/api/settings.py
@@ -1,9 +1,5 @@
 import os
 
-KEYCLOAK_BASE_URL = os.getenv("KEYCLOAK_BASE_URL", "default_base_url")
-REALM = os.getenv("REALM", "default_realm")
-CLIENT_ID = os.getenv("CLIENT_ID", "default_client_id")
-CLIENT_SECRET = os.getenv("CLIENT_SECRET", "default_client_secret")
 CACHE_CONTROL_HEADERS = os.getenv("CACHE_CONTROL_HEADERS", "max-age=300, stale-while-revalidate=300")
 CACHE_CONTROL_CATALOGS = os.getenv("CACHE_CONTROL_CATALOGS", "supported-datasets")
 CACHE_CONTROL_CATALOGS_LIST = CACHE_CONTROL_CATALOGS.split(',')


### PR DESCRIPTION
## Update for New Workspaces-Scoped Tokens
- Remove token exchange function, as `workspaces` are already included in the incoming token
- Extract `workspaces` from the raw input token
- Also extract `user_services` workspace to allow user-services to also access workspace data in the catalogue
- Add some logging to allow debugging of this functionality