### PR TITLE
Patch/update create root catalog uri path

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -125,13 +125,13 @@ class GetCatalogUri(APIRequest):
 class CreateCatalogUri(APIRequest):
     """Get or delete catalog."""
 
-    cat_path: Annotated[str, Path(description="Catalog path", regex=r"root$|(^([^/]+)(/catalogs/[^/]+)*$)")] = attr.ib()
+    cat_path: Annotated[str, Path(description="Catalog path", regex=r"^([^/]+)(/catalogs/[^/]+)*$")] = attr.ib()
 
 @attr.s
 class BaseCollectionSearchGetRequest(APIRequest):
     """Get or delete catalog."""
 
-    cat_path: Annotated[str, Path(description="Catalog path", regex=r"root$|(^([^/]+)(/catalogs/[^/]+)*$)")] = attr.ib()
+    cat_path: Annotated[str, Path(description="Catalog path", regex=r"^([^/]+)(/catalogs/[^/]+)*$")] = attr.ib()
     bbox: Optional[BBox] = attr.ib(default=None, converter=_bbox_converter)
     datetime: Optional[DateTimeType] = attr.ib(
         default=None, converter=_datetime_converter

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -66,6 +66,13 @@ class DeleteCollection(CollectionUri):
     workspace: str = attr.ib()
 
 @attr.s
+class PostRootCatalog(APIRequest):
+    """Create Root Catalog."""
+
+    workspace: str = attr.ib()
+    catalog: Annotated[Catalog, Body()] = attr.ib(default=None)
+
+@attr.s
 class PostCatalog(CreateCatalogUri):
     """Create Catalog."""
 
@@ -262,7 +269,7 @@ class TransactionExtension(ApiExtension):
         )
 
     def register_create_catalog(self):
-        """Register create Catalog endpoint (POST /catalogs)."""
+        """Register create Catalog endpoint (POST /catalogs/{cat_path}/catalogs)."""
         self.router.add_api_route(
             name="Create Catalog",
             path="/catalogs/{cat_path:path}/catalogs",
@@ -281,6 +288,28 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["POST"],
             endpoint=create_async_endpoint(self.client.create_catalog, PostCatalog),
+        )
+
+    def register_create_root_catalog(self):
+        """Register create root Catalog endpoint (POST /catalogs)."""
+        self.router.add_api_route(
+            name="Create Root Catalog",
+            path="/catalogs",
+            status_code=201,
+            response_model=Catalog if self.settings.enable_response_models else None,
+            responses={
+                201: {
+                    "content": {
+                        MimeTypes.json.value: {},
+                    },
+                    "model": Catalog,
+                }
+            },
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["POST"],
+            endpoint=create_async_endpoint(self.client.create_catalog, PostRootCatalog),
         )
 
     def register_update_catalog(self):
@@ -391,6 +420,7 @@ class TransactionExtension(ApiExtension):
         self.register_update_collection()
         self.register_delete_collection()
         self.register_create_catalog()
+        self.register_create_root_catalog()
         self.register_update_catalog()
         
         self.register_delete_catalog()

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -411,17 +411,16 @@ class TransactionExtension(ApiExtension):
             None
         """
         self.router.prefix = app.state.router_prefix
+        self.register_update_collection_access_control()
+        self.register_update_catalog_access_control()
         self.register_create_item()
         self.register_update_item()
         self.register_delete_item()
-        self.register_update_catalog_access_control()
-        self.register_update_collection_access_control()
         self.register_create_collection()
         self.register_update_collection()
         self.register_delete_collection()
         self.register_create_catalog()
         self.register_create_root_catalog()
         self.register_update_catalog()
-        
         self.register_delete_catalog()
         app.include_router(self.router, tags=["Transaction Extension"])

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -165,7 +165,7 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def create_catalog(
-        self, catalog: Catalog, cat_path: str, workspace: str, **kwargs
+        self, catalog: Catalog, workspace: str, cat_path: Optional[str]=None, **kwargs
     ) -> Optional[Union[stac.Catalog, Response]]:
         """Create a new catalog.
 
@@ -392,7 +392,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def create_catalog(
-        self, cat_path: str, catalog: Catalog, workspace: str, **kwargs
+        self, catalog: Catalog, workspace: str, cat_path: Optional[str]=None, **kwargs
     ) -> Optional[Union[stac.Catalog, Response]]:
         """Create a new catalog.
 


### PR DESCRIPTION
## Update create_catalog endpoint for `root` catalogs
- Add new endpoint for root catalog creation
- endpoint is `/catalogs` no need for `root` keyword
- allow `catalog_path` to be optional in create_catalog functions
- we can determine root catalogs if `cat_path` is `None`